### PR TITLE
Enhancement: Implement NormalizePlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Latest Stable Version](https://poser.pugx.org/localheinz/composer-normalize/v/stable)](https://packagist.org/packages/localheinz/composer-normalize)
 [![Total Downloads](https://poser.pugx.org/localheinz/composer-normalize/downloads)](https://packagist.org/packages/localheinz/composer-normalize)
 
+Provides a composer plugin for normalizing `composer.json`.
+
 ## Installation
 
 Run
@@ -15,7 +17,30 @@ $ composer global require localheinz/composer-normalize
 
 ## Usage
 
-This package comes with the following normalizers:
+Run
+
+```
+$ composer normalize
+```
+
+to normalize `composer.json` in the working directory.
+
+The `NormalizeCommand` provided by the `NormalizePlugin` within this package will
+
+* determine whether a `composer.json` exists
+* determine whether a `composer.lock` exists, and if so, whether it is up to date
+* pass the content of `composer.json` through a chain of normalizers
+* write the normalized content of `composer.json` back to the file
+* update the hash in `composer.lock` if it exists and if an update is necessary
+
+## Normalizers
+
+This package makes use of the following normalizers provided by [`localheinz/json-normalizer`](https://github.com/localheinz/json-normalizer).
+
+* [`Localheinz\Json\Normalizer\AutoFormatNormalizer`](https://github.com/localheinz/json-normalizer#autoformatnormalizer)
+* [`Localheinz\Json\Normalizer\ChainNormalizer`](https://github.com/localheinz/json-normalizer#chainnormalizer)
+
+Additionally, it provides and makes use of the following normalizers:
 
 * [`Localheinz\Composer\Normalize\Normalizer\ConfigHashNormalizer`](#confighashnormalizer)
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "localheinz/json-normalizer": "dev-master#3a07f98"
   },
   "require-dev": {
-    "composer/composer": "^1.0.0",
+    "composer/composer": "^1.1.0",
     "infection/infection": "~0.7.0",
     "localheinz/php-cs-fixer-config": "~1.11.0",
     "localheinz/test-util": "0.6.1",

--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,8 @@
     "psr-4": {
       "Localheinz\\Composer\\Normalize\\Test\\": "test/"
     }
+  },
+  "extra": {
+    "class": "Localheinz\\Composer\\Normalize\\NormalizePlugin"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
   },
   "require": {
     "php": "^7.0",
+    "composer-plugin-api": "^1.1.0",
     "localheinz/json-normalizer": "dev-master#3a07f98"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "10691373894c0fa5d22a0121c441704f",
+    "content-hash": "3f5804aa904846246dfcc5fe213115b7",
     "packages": [
         {
             "name": "localheinz/json-normalizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8752291b7dd4a338044185fc8c745181",
+    "content-hash": "10691373894c0fa5d22a0121c441704f",
     "packages": [
         {
             "name": "localheinz/json-normalizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f5804aa904846246dfcc5fe213115b7",
+    "content-hash": "025c68a91a39097e3a36a7a2dbeb6536",
     "packages": [
         {
             "name": "localheinz/json-normalizer",

--- a/src/NormalizePlugin.php
+++ b/src/NormalizePlugin.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/composer-normalize
+ */
+
+namespace Localheinz\Composer\Normalize;
+
+use Composer\Composer;
+use Composer\IO;
+use Composer\Plugin;
+use Localheinz\Json\Normalizer\AutoFormatNormalizer;
+use Localheinz\Json\Normalizer\ChainNormalizer;
+
+final class NormalizePlugin implements Plugin\PluginInterface, Plugin\Capable, Plugin\Capability\CommandProvider
+{
+    /**
+     * @var Composer
+     */
+    private $composer;
+
+    /**
+     * @var IO\IOInterface
+     */
+    private $io;
+
+    public function activate(Composer $composer, IO\IOInterface $io)
+    {
+        $this->composer = $composer;
+        $this->io = $io;
+    }
+
+    public function getCapabilities(): array
+    {
+        return [
+            Plugin\Capability\CommandProvider::class => self::class,
+        ];
+    }
+
+    public function getCommands(): array
+    {
+        return [
+            new Command\NormalizeCommand(new AutoFormatNormalizer(new ChainNormalizer(
+                new Normalizer\ConfigHashNormalizer()
+            ))),
+        ];
+    }
+}

--- a/test/Unit/NormalizePluginTest.php
+++ b/test/Unit/NormalizePluginTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/composer-normalize
+ */
+
+namespace Localheinz\Composer\Normalize\Test\Unit;
+
+use Composer\Composer;
+use Composer\IO;
+use Composer\Plugin;
+use Localheinz\Composer\Normalize\Command\NormalizeCommand;
+use Localheinz\Composer\Normalize\NormalizePlugin;
+use Localheinz\Test\Util\Helper;
+use PHPUnit\Framework;
+
+final class NormalizePluginTest extends Framework\TestCase
+{
+    use Helper;
+
+    /**
+     * @dataProvider providerInterfaceName
+     *
+     * @param string $interfaceName
+     */
+    public function testImplementsPluginInterface(string $interfaceName)
+    {
+        $this->assertClassImplementsInterface($interfaceName, NormalizePlugin::class);
+    }
+
+    public function providerInterfaceName(): \Generator
+    {
+        $interfaces = [
+            Plugin\PluginInterface::class,
+            Plugin\Capable::class,
+            Plugin\Capability\CommandProvider::class,
+        ];
+
+        foreach ($interfaces as $interface) {
+            yield $interface => [
+                $interface,
+            ];
+        }
+    }
+
+    public function testGetCapabilitiesReturnsCapabilities()
+    {
+        $plugin = new NormalizePlugin();
+
+        $plugin->activate(
+            $this->prophesize(Composer::class)->reveal(),
+            $this->prophesize(IO\IOInterface::class)->reveal()
+        );
+
+        $expected = [
+            Plugin\Capability\CommandProvider::class => NormalizePlugin::class,
+        ];
+
+        $this->assertSame($expected, $plugin->getCapabilities());
+    }
+
+    public function testProvidesNormalizeCommand()
+    {
+        $plugin = new NormalizePlugin();
+
+        $plugin->activate(
+            $this->prophesize(Composer::class)->reveal(),
+            $this->prophesize(IO\IOInterface::class)->reveal()
+        );
+
+        $commands = $plugin->getCommands();
+
+        $this->assertCount(1, $commands);
+
+        $command = \array_shift($commands);
+
+        $this->assertInstanceOf(NormalizeCommand::class, $command);
+    }
+}


### PR DESCRIPTION
This PR

* [x] requires `composer-plugin-api`n
* [x] implements a `NormalizePlugin`, which provides the previously implemented `NormalizeCommand`
* [x] requires `composer/composer:^1.1.0`