### PR TITLE
Fix: Disable plugins when updating lock file

### DIFF
--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -131,7 +131,7 @@ final class NormalizeCommand extends Command\BaseCommand
     private function updateLocker(): int
     {
         return $this->getApplication()->run(
-            new Console\Input\StringInput('update --lock'),
+            new Console\Input\StringInput('update --lock --no-plugins'),
             new Console\Output\NullOutput()
         );
     }

--- a/test/Unit/Command/NormalizeCommandTest.php
+++ b/test/Unit/Command/NormalizeCommandTest.php
@@ -502,7 +502,7 @@ final class NormalizeCommandTest extends Framework\TestCase
                 Argument::allOf(
                     Argument::type(Console\Input\StringInput::class),
                     Argument::that(function (Console\Input\StringInput $input) {
-                        return 'update --lock' === (string) $input;
+                        return 'update --lock --no-plugins' === (string) $input;
                     })
                 ),
                 Argument::type(Console\Output\NullOutput::class)
@@ -588,7 +588,7 @@ final class NormalizeCommandTest extends Framework\TestCase
                 Argument::allOf(
                     Argument::type(Console\Input\StringInput::class),
                     Argument::that(function (Console\Input\StringInput $input) {
-                        return 'update --lock' === (string) $input;
+                        return 'update --lock --no-plugins' === (string) $input;
                     })
                 ),
                 Argument::type(Console\Output\NullOutput::class)


### PR DESCRIPTION
This PR

* [x] disables plugins when updating the lock file

Follows #1.