### PR TITLE
Fix: Handle empty hashes

### DIFF
--- a/src/Normalizer/ConfigHashNormalizer.php
+++ b/src/Normalizer/ConfigHashNormalizer.php
@@ -34,6 +34,10 @@ final class ConfigHashNormalizer implements NormalizerInterface
 
         $config = (array) $decoded->config;
 
+        if (!\count($config)) {
+            return $json;
+        }
+
         \ksort($config);
 
         $decoded->config = $config;

--- a/src/Normalizer/PackageHashNormalizer.php
+++ b/src/Normalizer/PackageHashNormalizer.php
@@ -51,7 +51,13 @@ final class PackageHashNormalizer implements NormalizerInterface
         }
 
         foreach ($objectProperties as $name => $value) {
-            $decoded->{$name} = $this->sortPackages((array) $decoded->{$name});
+            $packages = (array) $decoded->{$name};
+
+            if (!\count($packages)) {
+                continue;
+            }
+
+            $decoded->{$name} = $this->sortPackages($packages);
         }
 
         return \json_encode($decoded);

--- a/test/Unit/Normalizer/ConfigHashNormalizerTest.php
+++ b/test/Unit/Normalizer/ConfigHashNormalizerTest.php
@@ -33,6 +33,19 @@ JSON;
         $this->assertSame($json, $normalizer->normalize($json));
     }
 
+    public function testNormalizeIgnoresEmptyConfigHash()
+    {
+        $json = <<<'JSON'
+{
+  "config": {}
+}
+JSON;
+
+        $normalizer = new ConfigHashNormalizer();
+
+        $this->assertSame($json, $normalizer->normalize($json));
+    }
+
     public function testNormalizeSortsConfigHashIfPropertyExists()
     {
         $json = <<<'JSON'

--- a/test/Unit/Normalizer/PackageHashNormalizerTest.php
+++ b/test/Unit/Normalizer/PackageHashNormalizerTest.php
@@ -38,6 +38,24 @@ JSON;
      *
      * @param string $property
      */
+    public function testNormalizeIgnoresEmptyPackageHash(string $property)
+    {
+        $json = <<<JSON
+{
+  "${property}": {}
+}
+JSON;
+
+        $normalizer = new PackageHashNormalizer();
+
+        $this->assertSame(\json_encode(\json_decode($json)), $normalizer->normalize($json));
+    }
+
+    /**
+     * @dataProvider providerProperty
+     *
+     * @param string $property
+     */
     public function testNormalizeSortsPackageHashIfPropertyExists(string $property)
     {
         $json = <<<JSON


### PR DESCRIPTION
This PR

* [x] handles empty config and package hashes

Follows #2.
Follows #6.