### PR TITLE
Fix: Use --no-scripts option when invoking UpdateCommand

### DIFF
--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -126,7 +126,7 @@ final class NormalizeCommand extends Command\BaseCommand
     private function updateLocker(): int
     {
         return $this->getApplication()->run(
-            new Console\Input\StringInput('update --lock --no-plugins'),
+            new Console\Input\StringInput('update --lock --no-plugins --no-scripts'),
             new Console\Output\NullOutput()
         );
     }

--- a/test/Unit/Command/NormalizeCommandTest.php
+++ b/test/Unit/Command/NormalizeCommandTest.php
@@ -521,7 +521,7 @@ final class NormalizeCommandTest extends Framework\TestCase
                 Argument::allOf(
                     Argument::type(Console\Input\StringInput::class),
                     Argument::that(function (Console\Input\StringInput $input) {
-                        return 'update --lock --no-plugins' === (string) $input;
+                        return 'update --lock --no-plugins --no-scripts' === (string) $input;
                     })
                 ),
                 Argument::type(Console\Output\NullOutput::class)


### PR DESCRIPTION
This PR

* [x] uses the `--no-scripts` option when invoking the `UpdateCommand`

Follows https://github.com/localheinz/composer-normalize/issues/15#issuecomment-357798798.

💁‍♂️ For reference, see https://getcomposer.org/doc/03-cli.md#update:

>### Options
>* **--no-scripts**: Skips execution of scripts defined in `composer.json`.

This suppresses scripts, for example, when having installed [`symfony/thanks`](https://github.com/symfony/thanks), it prevents rendering the suggestion to send ⭐️s (see [`Symfony\Thanks\Thanks`](https://github.com/symfony/thanks/blob/v1.0.1/src/Thanks.php#L77).

Thank you, @Soullivaneuh, for the suggestion!
