### PR TITLE
Fix: Use current output rather than NullOutput

### DIFF
--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -120,14 +120,14 @@ final class NormalizeCommand extends Command\BaseCommand
             return 0;
         }
 
-        return $this->updateLocker();
+        return $this->updateLocker($output);
     }
 
-    private function updateLocker(): int
+    private function updateLocker(Console\Output\OutputInterface $output): int
     {
         return $this->getApplication()->run(
             new Console\Input\StringInput('update --lock --no-plugins --no-scripts'),
-            new Console\Output\NullOutput()
+            $output
         );
     }
 }

--- a/test/Unit/Command/NormalizeCommandTest.php
+++ b/test/Unit/Command/NormalizeCommandTest.php
@@ -524,7 +524,7 @@ final class NormalizeCommandTest extends Framework\TestCase
                         return 'update --lock --no-plugins --no-scripts' === (string) $input;
                     })
                 ),
-                Argument::type(Console\Output\NullOutput::class)
+                Argument::type(Console\Output\OutputInterface::class)
             )
             ->shouldBeCalled()
             ->willReturn(0);


### PR DESCRIPTION
This PR

* [x] uses the current output rather than a `NullOutput`

💁‍♂️ This allows to see what is actually going on when passing in `-vvv` and siblings.