### PR TITLE
Enhancement: Output info before updating locker

### DIFF
--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -120,6 +120,8 @@ final class NormalizeCommand extends Command\BaseCommand
             return 0;
         }
 
+        $io->write('<info>Updating lock file.</info>');
+
         return $this->updateLocker($output);
     }
 

--- a/test/Unit/Command/NormalizeCommandTest.php
+++ b/test/Unit/Command/NormalizeCommandTest.php
@@ -465,6 +465,10 @@ final class NormalizeCommandTest extends Framework\TestCase
             )))
             ->shouldBeCalled();
 
+        $io
+            ->write(Argument::is('<info>Updating lock file.</info>'))
+            ->shouldBeCalled();
+
         $locker = $this->prophesize(Package\Locker::class);
 
         $locker


### PR DESCRIPTION
This PR

* [x] outputs an information message before updating locker

💁‍♂️ Otherwise it might be a bit confusing what is taking so long (with a lot of dependencies).