### PR TITLE
Enhancement: Add reference to FlintCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,7 @@ been adopted from [`Composer\Json\JsonManipulator::sortPackages()`](https://gith
 (originally licensed under MIT by [Nils Adermann](https://github.com/naderman) and [Jordi Boggiano](https://github.com/seldaek)), 
 which I initially contributed to `composer/composer` with [`composer/composer#3549`](https://github.com/composer/composer/pull/3549)
 and [`composer/composer#3872`](https://github.com/composer/composer/pull/3872).
+
+## Services
+
+`localheinz/composer-normalize` is currently in use by [FlintCI](https://flintci.io), see https://flintci.io/docs#composernormalize. 


### PR DESCRIPTION
This PR

* [x] adds a reference to services making use of `localheinz/composer-normalize`, in particular, [`FlintCI](https://flintci.io)
