### PR TITLE
Enhancement: Properly handle sections where schema type is an array rather than a scalar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": "^7.0",
     "composer-plugin-api": "^1.1.0",
-    "localheinz/json-normalizer": "0.1.0"
+    "localheinz/json-normalizer": "0.2.0"
   },
   "require-dev": {
     "composer/composer": "^1.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c800ab52a7324928da14422f234dd59e",
+    "content-hash": "c19a78fe1c706f680e1fa93b776e2082",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -74,16 +74,16 @@
         },
         {
             "name": "localheinz/json-normalizer",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localheinz/json-normalizer.git",
-                "reference": "443a53cef0a8adc96f857a79fb7c818fc7be388d"
+                "reference": "0ef5140e1669812ad69a50c2dad73c293bc3cdb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/json-normalizer/zipball/443a53cef0a8adc96f857a79fb7c818fc7be388d",
-                "reference": "443a53cef0a8adc96f857a79fb7c818fc7be388d",
+                "url": "https://api.github.com/repos/localheinz/json-normalizer/zipball/0ef5140e1669812ad69a50c2dad73c293bc3cdb6",
+                "reference": "0ef5140e1669812ad69a50c2dad73c293bc3cdb6",
                 "shasum": ""
             },
             "require": {
@@ -120,7 +120,7 @@
                 "json",
                 "normalizer"
             ],
-            "time": "2018-01-13T21:59:29+00:00"
+            "time": "2018-01-20T16:50:13+00:00"
         },
         {
             "name": "localheinz/json-printer",

--- a/test/Unit/Normalizer/ComposerJsonNormalizerTest.php
+++ b/test/Unit/Normalizer/ComposerJsonNormalizerTest.php
@@ -93,6 +93,15 @@ final class ComposerJsonNormalizerTest extends AbstractNormalizerTestCase
       "Helmut\\Foo\\Bar\\": "src/"
     }
   },
+  "scripts": {
+    "foo": "foo.sh",
+    "bar": "bar.sh",
+    "post-install-cmd": "@foo",
+    "pre-install-cmd": [
+      "@foo",
+      "@bar"
+    ]
+  },
   "autoload-dev": {
     "psr-4": {
       "Helmut\\Foo\\Bar\\Test\\": "test/"
@@ -149,7 +158,16 @@ JSON;
   "bin": [
     "hasenbein.php",
     "scripts/null-null.php"
-  ]
+  ],
+  "scripts": {
+    "pre-install-cmd": [
+      "@foo",
+      "@bar"
+    ],
+    "post-install-cmd": "@foo",
+    "bar": "bar.sh",
+    "foo": "foo.sh"
+  }
 }
 JSON;
 


### PR DESCRIPTION
This PR

* [x] adds a `scripts` section to the `ComposerJsonNormalizerTest`
* [x] updates `localheinz/json-normalizer`

💁‍♂️ For reference, see https://github.com/localheinz/json-normalizer/compare/0.1.0...0.2.0.