### PR TITLE
Fix: Skip autoloader and suggest when updating locker

### DIFF
--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -154,7 +154,7 @@ final class NormalizeCommand extends Command\BaseCommand
     private function updateLocker(Console\Output\OutputInterface $output): int
     {
         return $this->getApplication()->run(
-            new Console\Input\StringInput('update --lock --no-plugins --no-scripts'),
+            new Console\Input\StringInput('update --lock --no-autoloader --no-plugins --no-scripts --no-suggest'),
             $output
         );
     }

--- a/test/Unit/Command/NormalizeCommandTest.php
+++ b/test/Unit/Command/NormalizeCommandTest.php
@@ -575,7 +575,7 @@ final class NormalizeCommandTest extends Framework\TestCase
                 Argument::allOf(
                     Argument::type(Console\Input\StringInput::class),
                     Argument::that(function (Console\Input\StringInput $input) {
-                        return 'update --lock --no-plugins --no-scripts' === (string) $input;
+                        return 'update --lock --no-autoloader --no-plugins --no-scripts --no-suggest' === (string) $input;
                     })
                 ),
                 Argument::type(Console\Output\OutputInterface::class)


### PR DESCRIPTION
This PR

* [x] skips autloader generation and suggesting packages when updating locker