### PR TITLE
Fix: Handle empty namespace prefixes

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -11,7 +11,7 @@ the LICENSE file that was distributed with this source code.
 @see https://github.com/localheinz/composer-normalize
 EOF;
 
-$config = Config\Factory::fromRuleSet(new Config\RuleSet\Php70($header));
+$config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));
 
 $config->getFinder()->in(__DIR__);
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
   include:
     - stage: Style
 
-      php: 7.0
+      php: 7.1
 
       before_install:
         - source .travis/xdebug.sh
@@ -40,7 +40,7 @@ jobs:
 
       stage: Test
 
-      php: 7.0
+      php: 7.1
 
       env: WITH_LOWEST=true
 
@@ -62,24 +62,6 @@ jobs:
 
       after_success:
         - if [[ "$WITH_COVERAGE" == "true" ]]; then bash <(curl -s https://codecov.io/bash); fi
-
-    - <<: *TEST
-
-      php: 7.0
-
-      env: WITH_LOCKED=true
-
-    - <<: *TEST
-
-      php: 7.0
-
-      env: WITH_HIGHEST=true
-
-    - <<: *TEST
-
-      php: 7.1
-
-      env: WITH_LOWEST=true
 
     - <<: *TEST
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^7.0",
+    "php": "^7.1",
     "composer-plugin-api": "^1.1.0",
     "localheinz/json-normalizer": "0.2.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c19a78fe1c706f680e1fa93b776e2082",
+    "content-hash": "60d0b9397d33bd97fa027c0348f518a5",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -3651,7 +3651,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.0"
+        "php": "^7.1"
     },
     "platform-dev": []
 }

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -32,7 +32,7 @@ final class NormalizeCommand extends Command\BaseCommand
         $this->normalizer = $normalizer;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDescription('Normalizes composer.json according to its JSON schema (https://getcomposer.org/schema.json).');
         $this->setDefinition([

--- a/src/Normalizer/VersionConstraintNormalizer.php
+++ b/src/Normalizer/VersionConstraintNormalizer.php
@@ -85,7 +85,7 @@ final class VersionConstraintNormalizer implements NormalizerInterface
     {
         $normalized = $versionConstraint;
 
-        foreach (self::$map as list($pattern, $glue)) {
+        foreach (self::$map as [$pattern, $glue]) {
             $split = \preg_split(
                 $pattern,
                 $normalized

--- a/test/Unit/Command/NormalizeCommandTest.php
+++ b/test/Unit/Command/NormalizeCommandTest.php
@@ -46,12 +46,12 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->clearComposerFile();
     }
 
-    public function testExtendsBaseCommand()
+    public function testExtendsBaseCommand(): void
     {
         $this->assertClassExtends(Command\BaseCommand::class, NormalizeCommand::class);
     }
 
-    public function testHasNameAndDescription()
+    public function testHasNameAndDescription(): void
     {
         $command = new NormalizeCommand($this->prophesize(Normalizer\NormalizerInterface::class)->reveal());
 
@@ -59,7 +59,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->assertSame('Normalizes composer.json according to its JSON schema (https://getcomposer.org/schema.json).', $command->getDescription());
     }
 
-    public function testHasNoArguments()
+    public function testHasNoArguments(): void
     {
         $command = new NormalizeCommand($this->prophesize(Normalizer\NormalizerInterface::class)->reveal());
 
@@ -68,7 +68,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->assertCount(0, $definition->getArguments());
     }
 
-    public function testHasNoUpdateLockOption()
+    public function testHasNoUpdateLockOption(): void
     {
         $command = new NormalizeCommand($this->prophesize(Normalizer\NormalizerInterface::class)->reveal());
 
@@ -84,7 +84,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->assertSame('Do not update lock file if it exists', $option->getDescription());
     }
 
-    public function testExecuteFailsIfComposerFileDoesNotExist()
+    public function testExecuteFailsIfComposerFileDoesNotExist(): void
     {
         $composerFile = $this->pathToNonExistentComposerFile();
 
@@ -109,7 +109,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->assertFileNotExists($composerFile);
     }
 
-    public function testExecuteFailsIfComposerFileIsNotReadable()
+    public function testExecuteFailsIfComposerFileIsNotReadable(): void
     {
         $original = $this->composerFileContent();
 
@@ -141,7 +141,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->assertStringEqualsFile($composerFile, $original);
     }
 
-    public function testExecuteFailsIfComposerFileIsNotWritable()
+    public function testExecuteFailsIfComposerFileIsNotWritable(): void
     {
         $original = $this->composerFileContent();
 
@@ -173,7 +173,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->assertStringEqualsFile($composerFile, $original);
     }
 
-    public function testExecuteFailsIfLockerIsLockedButNotFresh()
+    public function testExecuteFailsIfLockerIsLockedButNotFresh(): void
     {
         $original = $this->composerFileContent();
 
@@ -218,7 +218,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->assertStringEqualsFile($composerFile, $original);
     }
 
-    public function testExecuteFailsIfNormalizerThrowsInvalidArgumentException()
+    public function testExecuteFailsIfNormalizerThrowsInvalidArgumentException(): void
     {
         $faker = $this->faker();
 
@@ -305,7 +305,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->assertStringEqualsFile($composerFile, $original);
     }
 
-    public function testExecuteFailsIfNormalizerThrowsRuntimeException()
+    public function testExecuteFailsIfNormalizerThrowsRuntimeException(): void
     {
         $exception = new \RuntimeException($this->faker()->sentence);
 
@@ -362,7 +362,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->assertStringEqualsFile($composerFile, $original);
     }
 
-    public function testExecuteSucceedsIfLockerIsNotLockedAndComposerFileIsAlreadyNormalized()
+    public function testExecuteSucceedsIfLockerIsNotLockedAndComposerFileIsAlreadyNormalized(): void
     {
         $original = $this->composerFileContent();
 
@@ -412,7 +412,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->assertStringEqualsFile($composerFile, $original);
     }
 
-    public function testExecuteSucceedsIfLockerIsLockedAndFreshButComposerFileIsAlreadyNormalized()
+    public function testExecuteSucceedsIfLockerIsLockedAndFreshButComposerFileIsAlreadyNormalized(): void
     {
         $original = $this->composerFileContent();
 
@@ -467,7 +467,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->assertStringEqualsFile($composerFile, $original);
     }
 
-    public function testExecuteSucceedsIfLockerIsNotLockedAndComposerFileWasNormalizedSuccessfully()
+    public function testExecuteSucceedsIfLockerIsNotLockedAndComposerFileWasNormalizedSuccessfully(): void
     {
         $original = $this->composerFileContent();
 
@@ -522,7 +522,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->assertStringEqualsFile($composerFile, $normalized);
     }
 
-    public function testExecuteSucceedsIfLockerIsLockedAndLockerCouldBeUpdatedAfterNormalization()
+    public function testExecuteSucceedsIfLockerIsLockedAndLockerCouldBeUpdatedAfterNormalization(): void
     {
         $original = $this->composerFileContent();
 
@@ -612,7 +612,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $this->assertStringEqualsFile($composerFile, $normalized);
     }
 
-    public function testExecuteSucceedsIfLockerIsLockedButSkipsUpdatingLockerIfNoUpdateLockOptionIsUsed()
+    public function testExecuteSucceedsIfLockerIsLockedButSkipsUpdatingLockerIfNoUpdateLockOptionIsUsed(): void
     {
         $original = $this->composerFileContent();
 
@@ -760,7 +760,7 @@ final class NormalizeCommandTest extends Framework\TestCase
     /**
      * @see Factory::getComposerFile()
      */
-    private function clearComposerFile()
+    private function clearComposerFile(): void
     {
         \putenv('COMPOSER');
     }

--- a/test/Unit/NormalizePluginTest.php
+++ b/test/Unit/NormalizePluginTest.php
@@ -51,7 +51,7 @@ final class NormalizePluginTest extends Framework\TestCase
         }
     }
 
-    public function testGetCapabilitiesReturnsCapabilities()
+    public function testGetCapabilitiesReturnsCapabilities(): void
     {
         $plugin = new NormalizePlugin();
 
@@ -67,7 +67,7 @@ final class NormalizePluginTest extends Framework\TestCase
         $this->assertSame($expected, $plugin->getCapabilities());
     }
 
-    public function testProvidesNormalizeCommand()
+    public function testProvidesNormalizeCommand(): void
     {
         $plugin = new NormalizePlugin();
 

--- a/test/Unit/Normalizer/AbstractNormalizerTestCase.php
+++ b/test/Unit/Normalizer/AbstractNormalizerTestCase.php
@@ -21,12 +21,12 @@ abstract class AbstractNormalizerTestCase extends Framework\TestCase
 {
     use Helper;
 
-    final public function testImplementsNormalizerInterface()
+    final public function testImplementsNormalizerInterface(): void
     {
         $this->assertClassImplementsInterface(NormalizerInterface::class, $this->className());
     }
 
-    final public function testNormalizeRejectsInvalidJson()
+    final public function testNormalizeRejectsInvalidJson(): void
     {
         $json = $this->faker()->realText();
 

--- a/test/Unit/Normalizer/BinNormalizerTest.php
+++ b/test/Unit/Normalizer/BinNormalizerTest.php
@@ -17,7 +17,7 @@ use Localheinz\Composer\Normalize\Normalizer\BinNormalizer;
 
 final class BinNormalizerTest extends AbstractNormalizerTestCase
 {
-    public function testNormalizeDoesNotModifyOtherProperty()
+    public function testNormalizeDoesNotModifyOtherProperty(): void
     {
         $json = <<<'JSON'
 {
@@ -33,7 +33,7 @@ JSON;
         $this->assertSame($json, $normalizer->normalize($json));
     }
 
-    public function testNormalizeDoesNotModifyBinIfPropertyExistsAsString()
+    public function testNormalizeDoesNotModifyBinIfPropertyExistsAsString(): void
     {
         $json = <<<'JSON'
 {
@@ -50,7 +50,7 @@ JSON;
         $this->assertSame($json, $normalizer->normalize($json));
     }
 
-    public function testNormalizeSortsBinIfPropertyExistsAsArray()
+    public function testNormalizeSortsBinIfPropertyExistsAsArray(): void
     {
         $json = <<<'JSON'
 {

--- a/test/Unit/Normalizer/ComposerJsonNormalizerTest.php
+++ b/test/Unit/Normalizer/ComposerJsonNormalizerTest.php
@@ -25,7 +25,7 @@ use Localheinz\Json\Normalizer\SchemaNormalizer;
 
 final class ComposerJsonNormalizerTest extends AbstractNormalizerTestCase
 {
-    public function testComposesNormalizers()
+    public function testComposesNormalizers(): void
     {
         $normalizer = new ComposerJsonNormalizer();
 
@@ -55,7 +55,7 @@ final class ComposerJsonNormalizerTest extends AbstractNormalizerTestCase
         $this->assertAttributeSame('https://getcomposer.org/schema.json', 'schemaUri', $schemaNormalizer);
     }
 
-    public function testNormalizeNormalizes()
+    public function testNormalizeNormalizes(): void
     {
         $json = <<<'JSON'
 {
@@ -181,7 +181,7 @@ JSON;
         $this->assertSame($normalized, $normalizer->normalize($json));
     }
 
-    private function assertComposesNormalizer(string $className, NormalizerInterface $normalizer)
+    private function assertComposesNormalizer(string $className, NormalizerInterface $normalizer): void
     {
         $this->assertClassExists($className);
         $this->assertClassImplementsInterface(NormalizerInterface::class, $className);
@@ -201,7 +201,7 @@ JSON;
         ));
     }
 
-    private function assertComposesNormalizers(array $classNames, NormalizerInterface $normalizer)
+    private function assertComposesNormalizers(array $classNames, NormalizerInterface $normalizer): void
     {
         foreach ($classNames as $className) {
             $this->assertClassExists($className);

--- a/test/Unit/Normalizer/ComposerJsonNormalizerTest.php
+++ b/test/Unit/Normalizer/ComposerJsonNormalizerTest.php
@@ -90,6 +90,7 @@ final class ComposerJsonNormalizerTest extends AbstractNormalizerTestCase
   },
   "autoload": {
     "psr-4": {
+      "": "/foo",
       "Helmut\\Foo\\Bar\\": "src/"
     }
   },
@@ -147,6 +148,7 @@ JSON;
   },
   "autoload": {
     "psr-4": {
+      "": "/foo",
       "Helmut\\Foo\\Bar\\": "src/"
     }
   },

--- a/test/Unit/Normalizer/ConfigHashNormalizerTest.php
+++ b/test/Unit/Normalizer/ConfigHashNormalizerTest.php
@@ -17,7 +17,7 @@ use Localheinz\Composer\Normalize\Normalizer\ConfigHashNormalizer;
 
 final class ConfigHashNormalizerTest extends AbstractNormalizerTestCase
 {
-    public function testNormalizeDoesNotModifyOtherProperty()
+    public function testNormalizeDoesNotModifyOtherProperty(): void
     {
         $json = <<<'JSON'
 {
@@ -33,7 +33,7 @@ JSON;
         $this->assertSame($json, $normalizer->normalize($json));
     }
 
-    public function testNormalizeIgnoresEmptyConfigHash()
+    public function testNormalizeIgnoresEmptyConfigHash(): void
     {
         $json = <<<'JSON'
 {
@@ -46,7 +46,7 @@ JSON;
         $this->assertSame($json, $normalizer->normalize($json));
     }
 
-    public function testNormalizeSortsConfigHashIfPropertyExists()
+    public function testNormalizeSortsConfigHashIfPropertyExists(): void
     {
         $json = <<<'JSON'
 {

--- a/test/Unit/Normalizer/PackageHashNormalizerTest.php
+++ b/test/Unit/Normalizer/PackageHashNormalizerTest.php
@@ -17,7 +17,7 @@ use Localheinz\Composer\Normalize\Normalizer\PackageHashNormalizer;
 
 final class PackageHashNormalizerTest extends AbstractNormalizerTestCase
 {
-    public function testNormalizeDoesNotModifyOtherProperty()
+    public function testNormalizeDoesNotModifyOtherProperty(): void
     {
         $json = <<<'JSON'
 {
@@ -38,7 +38,7 @@ JSON;
      *
      * @param string $property
      */
-    public function testNormalizeIgnoresEmptyPackageHash(string $property)
+    public function testNormalizeIgnoresEmptyPackageHash(string $property): void
     {
         $json = <<<JSON
 {
@@ -56,7 +56,7 @@ JSON;
      *
      * @param string $property
      */
-    public function testNormalizeSortsPackageHashIfPropertyExists(string $property)
+    public function testNormalizeSortsPackageHashIfPropertyExists(string $property): void
     {
         $json = <<<JSON
 {

--- a/test/Unit/Normalizer/VersionConstraintNormalizerTest.php
+++ b/test/Unit/Normalizer/VersionConstraintNormalizerTest.php
@@ -22,7 +22,7 @@ final class VersionConstraintNormalizerTest extends AbstractNormalizerTestCase
      *
      * @param string $constraint
      */
-    public function testNormalizeDoesNotModifyOtherProperty(string $constraint)
+    public function testNormalizeDoesNotModifyOtherProperty(string $constraint): void
     {
         $json = <<<JSON
 {
@@ -51,7 +51,7 @@ JSON;
      *
      * @param string $property
      */
-    public function testNormalizeIgnoresEmptyPackageHash(string $property)
+    public function testNormalizeIgnoresEmptyPackageHash(string $property): void
     {
         $json = <<<JSON
 {
@@ -82,7 +82,7 @@ JSON;
      * @param string $versionConstraint
      * @param string $normalizedVersionConstraint
      */
-    public function testNormalizeNormalizesVersionConstraints(string $property, string $versionConstraint, string $normalizedVersionConstraint)
+    public function testNormalizeNormalizesVersionConstraints(string $property, string $versionConstraint, string $normalizedVersionConstraint): void
     {
         $json = <<<JSON
 {
@@ -128,7 +128,7 @@ JSON;
      * @param string $versionConstraint
      * @param string $trimmedVersionConstraint
      */
-    public function testNormalizeNormalizesTrimsVersionConstraints(string $property, string $versionConstraint, string $trimmedVersionConstraint)
+    public function testNormalizeNormalizesTrimsVersionConstraints(string $property, string $versionConstraint, string $trimmedVersionConstraint): void
     {
         $json = <<<JSON
 {

--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -20,12 +20,12 @@ final class ProjectCodeTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testProductionClassesAreAbstractOrFinal()
+    public function testProductionClassesAreAbstractOrFinal(): void
     {
         $this->assertClassesAreAbstractOrFinal(__DIR__ . '/../../src');
     }
 
-    public function testProductionClassesHaveTests()
+    public function testProductionClassesHaveTests(): void
     {
         $this->assertClassesHaveTests(
             __DIR__ . '/../../src',
@@ -34,7 +34,7 @@ final class ProjectCodeTest extends Framework\TestCase
         );
     }
 
-    public function testTestClassesAreAbstractOrFinal()
+    public function testTestClassesAreAbstractOrFinal(): void
     {
         $this->assertClassesAreAbstractOrFinal(__DIR__ . '/..');
     }


### PR DESCRIPTION
This PR

* [x] demonstrates a bug (or feature) with `json_decode` on PHP versions prior to 7.1
* [x] requires PHP 7.1

💁‍♂️ According to https://getcomposer.org/doc/04-schema.md#psr-4 it's perfectly fine to use an empty namespace prefix as a fallback:

>If you want to have a fallback directory where any namespace will be looked for, you can use an empty prefix like:
>
>```json
>{
>    "autoload": {
>        "psr-4": { "": "src/" }
>    }
>}

However, this is a problem with `json_encode()` on versions prior to PHP 7.1. 

See

- https://bugs.php.net/bug.php?id=46600
- https://3v4l.org/AbCjB

Possible workarounds could be

* use `json_decode($json, true)`, but has consequences when `$json` contains empty objects/arrays as both will be interpreted as empty arrays
* require PHP 7.1
