### PR TITLE
Fix: Extract method and rename method to make concepts clear

### DIFF
--- a/test/Unit/Normalizer/PackageHashNormalizerTest.php
+++ b/test/Unit/Normalizer/PackageHashNormalizerTest.php
@@ -99,7 +99,16 @@ JSON;
 
     public function providerProperty(): \Generator
     {
-        $values = [
+        foreach ($this->propertiesWhereKeysOfHashArePackages() as $value) {
+            yield $value => [
+                $value,
+            ];
+        }
+    }
+
+    private function propertiesWhereKeysOfHashArePackages(): array
+    {
+        return [
             'conflict',
             'provide',
             'replace',
@@ -107,11 +116,5 @@ JSON;
             'require-dev',
             'suggest',
         ];
-
-        foreach ($values as $value) {
-            yield $value => [
-                $value,
-            ];
-        }
     }
 }

--- a/test/Unit/Normalizer/VersionConstraintNormalizerTest.php
+++ b/test/Unit/Normalizer/VersionConstraintNormalizerTest.php
@@ -66,7 +66,7 @@ JSON;
 
     public function providerProperty(): \Generator
     {
-        $properties = $this->properties();
+        $properties = $this->propertiesWhereValuesOfHashAreVersionConstraints();
 
         foreach ($properties as $property) {
             yield [
@@ -107,7 +107,7 @@ JSON;
 
     public function providerPropertyAndVersionConstraint(): \Generator
     {
-        $properties = $this->properties();
+        $properties = $this->propertiesWhereValuesOfHashAreVersionConstraints();
         $versionConstraints = $this->versionConstraints();
 
         foreach ($properties as $property) {
@@ -158,7 +158,7 @@ JSON;
             ' ',
         ];
 
-        $properties = $this->properties();
+        $properties = $this->propertiesWhereValuesOfHashAreVersionConstraints();
         $versionConstraints = \array_unique(\array_values($this->versionConstraints()));
 
         foreach ($properties as $property) {
@@ -182,7 +182,7 @@ JSON;
         }
     }
 
-    private function properties(): array
+    private function propertiesWhereValuesOfHashAreVersionConstraints(): array
     {
         return [
             'conflict',


### PR DESCRIPTION
This PR

* [x] extracts a method and renames methods used in tests to make concepts clear

Follows #43.