### PR TITLE
Fix: Output diff without extra new lines

### DIFF
--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -217,10 +217,13 @@ final class NormalizeCommand extends Command\BaseCommand
                 '<fg=yellow>---------- begin diff ----------</>',
             ]);
 
-            $io->write($this->diff(
-                $json,
-                $formatted
-            ));
+            $io->write(
+                $this->diff(
+                    $json,
+                    $formatted
+                ),
+                false
+            );
 
             $io->write('<fg=yellow>----------- end diff -----------</>');
 

--- a/test/Unit/Command/NormalizeCommandTest.php
+++ b/test/Unit/Command/NormalizeCommandTest.php
@@ -1052,7 +1052,10 @@ final class NormalizeCommandTest extends Framework\TestCase
             ->shouldBeCalled();
 
         $io
-            ->write(Argument::type('array'))
+            ->write(
+                Argument::type('array'),
+                Argument::is(false)
+            )
             ->shouldBeCalled();
 
         $io


### PR DESCRIPTION
This PR

* [x] output diff without extra new lines