### PR TITLE
Enhancement: Adjust ConfigHashNormalizer to also sort extra section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,13 @@ the `BinNormalizer` will sort the elements of the `bin` section by value in asce
   
 ### `ConfigHashNormalizer`
 
-If `composer.json` contains any configuration in the `config` section, 
-the `ConfigHashNormalizer` will sort the `config` section by key in ascending order.
+If `composer.json` contains any configuration in the 
+
+* `config`
+* `extra` 
+
+sections, the `ConfigHashNormalizer` will sort the content of these sections 
+by key in ascending order.
 
 :bulb: Find out more about the `config` section at https://getcomposer.org/doc/06-config.md.  
 

--- a/test/Unit/Normalizer/ConfigHashNormalizerTest.php
+++ b/test/Unit/Normalizer/ConfigHashNormalizerTest.php
@@ -33,11 +33,16 @@ JSON;
         $this->assertSame($json, $normalizer->normalize($json));
     }
 
-    public function testNormalizeIgnoresEmptyConfigHash(): void
+    /**
+     * @dataProvider providerProperty
+     *
+     * @param string $property
+     */
+    public function testNormalizeIgnoresEmptyConfigHash(string $property): void
     {
-        $json = <<<'JSON'
+        $json = <<<JSON
 {
-  "config": {}
+  "${property}": {}
 }
 JSON;
 
@@ -46,11 +51,16 @@ JSON;
         $this->assertSame($json, $normalizer->normalize($json));
     }
 
-    public function testNormalizeSortsConfigHashIfPropertyExists(): void
+    /**
+     * @dataProvider providerProperty
+     *
+     * @param string $property
+     */
+    public function testNormalizeSortsConfigHashIfPropertyExists(string $property): void
     {
-        $json = <<<'JSON'
+        $json = <<<JSON
 {
-  "config": {
+  "${property}": {
     "sort-packages": true,
     "preferred-install": "dist"
   },
@@ -61,9 +71,9 @@ JSON;
 }
 JSON;
 
-        $normalized = <<<'JSON'
+        $normalized = <<<JSON
 {
-  "config": {
+  "${property}": {
     "preferred-install": "dist",
     "sort-packages": true
   },
@@ -77,5 +87,22 @@ JSON;
         $normalizer = new ConfigHashNormalizer();
 
         $this->assertSame(\json_encode(\json_decode($normalized)), $normalizer->normalize($json));
+    }
+
+    public function providerProperty(): \Generator
+    {
+        foreach ($this->properties() as $value) {
+            yield $value => [
+                $value,
+            ];
+        }
+    }
+
+    private function properties(): array
+    {
+        return [
+            'config',
+            'extra',
+        ];
     }
 }


### PR DESCRIPTION
This PR

* [x] adjusts the `ConfigHashNormalizer` to also sort the `extra` section

💁‍♂️ Not sure if this is a good idea, as it depends on how people use the `extra` section. Maybe order has a meaning there?
