### PR TITLE
Fix: Set indent size of Makefile to 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,4 +17,5 @@ indent_size = 4
 indent_size = 4
 
 [Makefile]
+indent_size = 4
 indent_style = tab


### PR DESCRIPTION
This PR

* [x] sets the indent size of `Makefile` to 4 spaces