### PR TITLE
Fix: Use void return type

### DIFF
--- a/test/Unit/Command/NormalizeCommandTest.php
+++ b/test/Unit/Command/NormalizeCommandTest.php
@@ -1794,7 +1794,7 @@ final class NormalizeCommandTest extends Framework\TestCase
      *
      * @param string $composerFile
      */
-    private function useComposerFile(string $composerFile)
+    private function useComposerFile(string $composerFile): void
     {
         \putenv(\sprintf(
             'COMPOSER=%s',

--- a/test/Unit/NormalizePluginTest.php
+++ b/test/Unit/NormalizePluginTest.php
@@ -34,7 +34,7 @@ final class NormalizePluginTest extends Framework\TestCase
      *
      * @param string $interfaceName
      */
-    public function testImplementsPluginInterface(string $interfaceName)
+    public function testImplementsPluginInterface(string $interfaceName): void
     {
         $this->assertClassImplementsInterface($interfaceName, NormalizePlugin::class);
     }


### PR DESCRIPTION
This PR

* [x] uses `void` return type on methods which do not use it yet