### PR TITLE
Fix: Overrride BaseCommand's initialize()

### DIFF
--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -109,6 +109,11 @@ final class NormalizeCommand extends Command\BaseCommand
         ]);
     }
 
+    protected function initialize(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): void
+    {
+        // nothing to initialize here
+    }
+
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
     {
         $io = $this->getIO();


### PR DESCRIPTION
This PR

* [x] overrides [`Composer\Command\BaseCommand::initialize()`](https://github.com/composer/composer/blob/1.7.2/src/Composer/Command/BaseCommand.php#L127-L145) as there is nothing there that we need in the context of the `NormalizeCommand` execution

💁‍♂️ This should fix the build.