### PR TITLE
Enhancement: Require localheinz/phpunit-framework-constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "composer/composer": "^1.1.0",
     "infection/infection": "^0.8.1",
     "localheinz/php-cs-fixer-config": "~1.15.0",
+    "localheinz/phpunit-framework-constraint": "~0.1.0",
     "localheinz/test-util": "0.6.1",
     "mikey179/vfsStream": "^1.6.5",
     "phpstan/phpstan": "~0.9.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82e865a4db55283ea398f32973ec73a6",
+    "content-hash": "8c073695a29e49b8edd45e43b137c55e",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -1176,6 +1176,59 @@
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "homepage": "https://github.com/localheinz/php-cs-fixer-config",
             "time": "2018-08-23T14:47:20+00:00"
+        },
+        {
+            "name": "localheinz/phpunit-framework-constraint",
+            "version": "0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localheinz/phpunit-framework-constraint.git",
+                "reference": "1b16447f387c4adfa6a8559f87b1a8d0734c1e09"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localheinz/phpunit-framework-constraint/zipball/1b16447f387c4adfa6a8559f87b1a8d0734c1e09",
+                "reference": "1b16447f387c4adfa6a8559f87b1a8d0734c1e09",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "phpunit/phpunit": "^7.0.0",
+                "sebastian/diff": "^3.0.0"
+            },
+            "require-dev": {
+                "infection/infection": "~0.10.5",
+                "localheinz/composer-normalize": "~0.8.0",
+                "localheinz/php-cs-fixer-config": "~1.15.0",
+                "localheinz/test-util": "~0.7.0",
+                "phpbench/phpbench": "~0.14.0",
+                "phpstan/phpstan": "~0.10.3",
+                "phpstan/phpstan-strict-rules": "~0.10.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Localheinz\\PHPUnit\\Framework\\Constraint\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides additional constraints and assertions for phpunit/phpunit",
+            "homepage": "https://github.com/localheinz/phpunit-framework-constraint",
+            "keywords": [
+                "assertion",
+                "constraint",
+                "phpunit"
+            ],
+            "time": "2018-10-05T08:05:29+00:00"
         },
         {
             "name": "localheinz/test-util",

--- a/test/Unit/Normalizer/AbstractNormalizerTestCase.php
+++ b/test/Unit/Normalizer/AbstractNormalizerTestCase.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Localheinz\Composer\Normalize\Test\Unit\Normalizer;
 
 use Localheinz\Json\Normalizer;
+use Localheinz\PHPUnit\Framework\Constraint\Provider;
 use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
 
@@ -23,6 +24,7 @@ use PHPUnit\Framework;
 abstract class AbstractNormalizerTestCase extends Framework\TestCase
 {
     use Helper;
+    use Provider;
 
     final public function testImplementsNormalizerInterface(): void
     {

--- a/test/Unit/Normalizer/BinNormalizerTest.php
+++ b/test/Unit/Normalizer/BinNormalizerTest.php
@@ -33,7 +33,7 @@ JSON;
 
         $normalizer = new BinNormalizer();
 
-        $this->assertSame($json, $normalizer->normalize($json));
+        $this->assertJsonStringSameAsJsonString($json, $normalizer->normalize($json));
     }
 
     public function testNormalizeDoesNotModifyBinIfPropertyExistsAsString(): void
@@ -50,7 +50,7 @@ JSON;
 
         $normalizer = new BinNormalizer();
 
-        $this->assertSame($json, $normalizer->normalize($json));
+        $this->assertJsonStringSameAsJsonString($json, $normalizer->normalize($json));
     }
 
     public function testNormalizeSortsBinIfPropertyExistsAsArray(): void

--- a/test/Unit/Normalizer/ConfigHashNormalizerTest.php
+++ b/test/Unit/Normalizer/ConfigHashNormalizerTest.php
@@ -33,7 +33,7 @@ JSON;
 
         $normalizer = new ConfigHashNormalizer();
 
-        $this->assertSame($json, $normalizer->normalize($json));
+        $this->assertJsonStringSameAsJsonString($json, $normalizer->normalize($json));
     }
 
     /**
@@ -51,7 +51,7 @@ JSON;
 
         $normalizer = new ConfigHashNormalizer();
 
-        $this->assertSame($json, $normalizer->normalize($json));
+        $this->assertJsonStringSameAsJsonString($json, $normalizer->normalize($json));
     }
 
     /**

--- a/test/Unit/Normalizer/PackageHashNormalizerTest.php
+++ b/test/Unit/Normalizer/PackageHashNormalizerTest.php
@@ -33,7 +33,7 @@ JSON;
 
         $normalizer = new PackageHashNormalizer();
 
-        $this->assertSame($json, $normalizer->normalize($json));
+        $this->assertJsonStringSameAsJsonString($json, $normalizer->normalize($json));
     }
 
     /**

--- a/test/Unit/Normalizer/VersionConstraintNormalizerTest.php
+++ b/test/Unit/Normalizer/VersionConstraintNormalizerTest.php
@@ -37,7 +37,7 @@ JSON;
 
         $normalizer = new VersionConstraintNormalizer();
 
-        $this->assertSame($json, $normalizer->normalize($json));
+        $this->assertJsonStringSameAsJsonString($json, $normalizer->normalize($json));
     }
 
     public function providerVersionConstraint(): \Generator


### PR DESCRIPTION
This PR

* [x] requires `localheinz/phpunit-framework-constraint`
* [x] uses `assertJsonStringIdenticalToJsonString()` assertion