### PR TITLE
Recommend only updating the lock file in exception

### DIFF
--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -163,7 +163,7 @@ final class NormalizeCommand extends Command\BaseCommand
         $locker = $composer->getLocker();
 
         if ($locker->isLocked() && !$locker->isFresh()) {
-            $io->writeError('<error>The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update`.</error>');
+            $io->writeError('<error>The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update --lock`.</error>');
 
             return 1;
         }

--- a/test/Unit/Command/NormalizeCommandTest.php
+++ b/test/Unit/Command/NormalizeCommandTest.php
@@ -430,7 +430,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         $io = $this->prophesize(IO\ConsoleIO::class);
 
         $io
-            ->writeError(Argument::is('<error>The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update`.</error>'))
+            ->writeError(Argument::is('<error>The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update --lock`.</error>'))
             ->shouldBeCalled();
 
         $locker = $this->prophesize(Package\Locker::class);


### PR DESCRIPTION
This PR will recommend the use of `composer update --lock` instead of `composer update`. This will ensure the `composer.lock` file is updated to match what's in `composer.json`, without causing any minor/patch version bumps. You can read more about this option in [the Composer documentation](https://getcomposer.org/doc/03-cli.md#update-u).