### PR TITLE
Fix: Do not attempt to fetch and modify properties of something that isn't an object

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,6 @@
 includes:
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
+
+parameters:
+	ignoreErrors:
+		- '#Access to an undefined property object::\$bin.#'

--- a/src/Normalizer/BinNormalizer.php
+++ b/src/Normalizer/BinNormalizer.php
@@ -28,7 +28,10 @@ final class BinNormalizer implements Normalizer\NormalizerInterface
             ));
         }
 
-        if (!\property_exists($decoded, 'bin') || !\is_array($decoded->bin)) {
+        if (!\is_object($decoded)
+            || !\property_exists($decoded, 'bin')
+            || !\is_array($decoded->bin)
+        ) {
             return $json;
         }
 

--- a/src/Normalizer/ComposerJsonNormalizer.php
+++ b/src/Normalizer/ComposerJsonNormalizer.php
@@ -35,11 +35,17 @@ final class ComposerJsonNormalizer implements Normalizer\NormalizerInterface
 
     public function normalize(string $json): string
     {
-        if (null === \json_decode($json) && \JSON_ERROR_NONE !== \json_last_error()) {
+        $decoded = \json_decode($json);
+
+        if (null === $decoded && \JSON_ERROR_NONE !== \json_last_error()) {
             throw new \InvalidArgumentException(\sprintf(
                 '"%s" is not valid JSON.',
                 $json
             ));
+        }
+
+        if (!\is_object($decoded)) {
+            return $json;
         }
 
         return $this->normalizer->normalize($json);

--- a/src/Normalizer/ConfigHashNormalizer.php
+++ b/src/Normalizer/ConfigHashNormalizer.php
@@ -36,6 +36,10 @@ final class ConfigHashNormalizer implements Normalizer\NormalizerInterface
             ));
         }
 
+        if (!\is_object($decoded)) {
+            return $json;
+        }
+
         $objectProperties = \array_intersect_key(
             \get_object_vars($decoded),
             \array_flip(self::$properties)

--- a/src/Normalizer/PackageHashNormalizer.php
+++ b/src/Normalizer/PackageHashNormalizer.php
@@ -41,6 +41,10 @@ final class PackageHashNormalizer implements Normalizer\NormalizerInterface
             ));
         }
 
+        if (!\is_object($decoded)) {
+            return $json;
+        }
+
         $objectProperties = \array_intersect_key(
             \get_object_vars($decoded),
             \array_flip(self::$properties)

--- a/src/Normalizer/VersionConstraintNormalizer.php
+++ b/src/Normalizer/VersionConstraintNormalizer.php
@@ -57,6 +57,10 @@ final class VersionConstraintNormalizer implements Normalizer\NormalizerInterfac
             ));
         }
 
+        if (!\is_object($decoded)) {
+            return $json;
+        }
+
         $objectProperties = \array_intersect_key(
             \get_object_vars($decoded),
             \array_flip(self::$properties)


### PR DESCRIPTION
This PR

* [x] asserts that normalizers skip normalization when `json_decode()`ed data is not an object
* [x] skips normalization when `json_decode()`ed data is not an object