### PR TITLE
Enhancement: Sort scripts-descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ If `composer.json` contains any configuration in the
 
 * `config`
 * `extra` 
+* `scripts-descriptions` 
 
 sections, the `ConfigHashNormalizer` will sort the content of these sections 
 by key in ascending order.

--- a/src/Normalizer/ConfigHashNormalizer.php
+++ b/src/Normalizer/ConfigHashNormalizer.php
@@ -23,6 +23,7 @@ final class ConfigHashNormalizer implements Normalizer\NormalizerInterface
     private static $properties = [
         'config',
         'extra',
+        'scripts-descriptions',
     ];
 
     public function normalize(string $json): string

--- a/test/Unit/Normalizer/ComposerJsonNormalizerTest.php
+++ b/test/Unit/Normalizer/ComposerJsonNormalizerTest.php
@@ -105,6 +105,12 @@ final class ComposerJsonNormalizerTest extends AbstractNormalizerTestCase
       "@bar"
     ]
   },
+  "scripts-descriptions": {
+    "foo": "Executes foo.sh",
+    "bar": "Executes bar.sh",
+    "post-install-cmd": "Runs foo",
+    "pre-install-cmd": "Runs foo and bar"
+  },
   "autoload-dev": {
     "psr-4": {
       "Helmut\\Foo\\Bar\\Test\\": "test/"
@@ -177,6 +183,12 @@ JSON;
     "post-install-cmd": "@foo",
     "bar": "bar.sh",
     "foo": "foo.sh"
+  },
+  "scripts-descriptions": {
+    "bar": "Executes bar.sh",
+    "foo": "Executes foo.sh",
+    "post-install-cmd": "Runs foo",
+    "pre-install-cmd": "Runs foo and bar"
   }
 }
 JSON;

--- a/test/Unit/Normalizer/ConfigHashNormalizerTest.php
+++ b/test/Unit/Normalizer/ConfigHashNormalizerTest.php
@@ -106,6 +106,7 @@ JSON;
         return [
             'config',
             'extra',
+            'scripts-descriptions',
         ];
     }
 }


### PR DESCRIPTION
This PR

* [x] adjusts the `ConfigHashNormalizer` to also sort the `scripts-descriptions` section

Fixes #88.

💁‍♂️ The only concern I have is that we now have a different kind mismatch between how `scripts` and `scripts-descriptions` are sorted.