### PR TITLE
Fix: Add note about static analysis and infection testing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,6 +28,30 @@ $ make cs
 
 to automatically fix coding standard violations.
 
+## Static Code Analysis
+
+We are using [`phpstan/phpstan`](https://github.com/phpstan/phpstan) to statically analyze the code.
+
+Run
+
+```
+$ make stan
+```
+
+to run a static code analysis.
+
+## Mutation Testing
+
+We are using [`infection/infection`](https://github.com/infection/infection) to ensure a minimum quality of the tests.
+
+Enable `xdebug` and run
+
+```
+$ make infection
+```
+
+to run mutation tests.
+
 ## Extra lazy?
 
 Run
@@ -36,4 +60,4 @@ Run
 $ make
 ```
 
-to run both coding standards check and tests!
+to enforce coding standards, perform a static code analysis, and run tests!


### PR DESCRIPTION
This PR

* [x] adds a note about running static analysis and infection testing to `CONTRIBUTING.md`