### PR TITLE
Fix: Remove upper constraint for phpunit/phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "mikey179/vfsStream": "^1.6.5",
     "phpstan/phpstan": "~0.9.2",
     "phpstan/phpstan-strict-rules": "^0.9.0",
-    "phpunit/phpunit": "^6.5.7 || ^7.1.5,<7.4.1"
+    "phpunit/phpunit": "^6.5.7 || ^7.1.5"
   },
   "config": {
     "preferred-install": "dist",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "803dc697df001ef2803e72e545e0f555",
+    "content-hash": "82e865a4db55283ea398f32973ec73a6",
     "packages": [
         {
             "name": "justinrainbow/json-schema",


### PR DESCRIPTION
This PR

* [x] removes the upper version constraint for `phpunit/phpunit`

Follows #95.