### PR TITLE
Fix: Configure rules via phpstan.neon instead of --level option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
         - composer install
 
       script:
-        - vendor/bin/phpstan analyse --configuration=phpstan.neon --level=max src
+        - vendor/bin/phpstan analyse --configuration=phpstan.neon src
 
     - &TEST
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ infection:
 	vendor/bin/infection --min-covered-msi=80 --min-msi=42
 
 stan: vendor
-	vendor/bin/phpstan analyse --configuration=phpstan.neon --level=max src
+	vendor/bin/phpstan analyse --configuration=phpstan.neon src
 
 test: vendor
 	vendor/bin/phpunit --configuration=test/AutoReview/phpunit.xml

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
+	- vendor/phpstan/phpstan/conf/config.levelmax.neon
 
 rules:
 	- Localheinz\PHPStan\Rules\Classes\AbstractOrFinalRule


### PR DESCRIPTION
This PR

* [x] configures rules via `phpstan.neon` instead of using `--level` option