### PR TITLE
Fix: Include rules.neon from localheinz/phpstan-rules

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,3 +2,9 @@ includes:
 	- vendor/localheinz/phpstan-rules/rules.neon
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
 	- vendor/phpstan/phpstan/conf/config.levelmax.neon
+
+parameters:
+	ignoreErrors:
+		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$differ with null as default value.#'
+		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$formatter with null as default value.#'
+		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::indentFrom\(\) has a nullable return type declaration.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,4 @@
 includes:
+	- vendor/localheinz/phpstan-rules/rules.neon
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
 	- vendor/phpstan/phpstan/conf/config.levelmax.neon
-
-rules:
-	- Localheinz\PHPStan\Rules\Classes\AbstractOrFinalRule


### PR DESCRIPTION
This PR

* [x] includes `rules.neon` from `localheinz/phpstan-rules`
* [x] ignores errors detected by static analysis for now