### PR TITLE
Fix: Require arguments to be passed in into the constructor of NormalizeCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## `2.0`
+
+### Unreleased
+
+For a full diff see [`1.0...master`](https://github.com/localheinz/composer-normalize/compare/1.0...master).
+
+#### Changed
+
+* The constructor of `NormalizeCommand` now requires an implementation of `Localheinz\Json\Normalizer\Format\FormatterInterface`, as well as an instance of `Sebastian\Diff\Differ` to be injected ([#118](https://github.com/localheinz/composer-normalize/pull/118)), by [@localheinz](https://github.com/localheinz)
+
 ## `1.0`
 
 ### Unreleased

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,8 +5,4 @@ includes:
 
 parameters:
 	ignoreErrors:
-		- '#Constructor in Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand has parameter \$differ with default value.#'
-		- '#Constructor in Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand has parameter \$formatter with default value.#'
-		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$differ with null as default value.#'
-		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$formatter with null as default value.#'
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::indentFrom\(\) has a nullable return type declaration.#'

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -52,15 +52,15 @@ final class NormalizeCommand extends Command\BaseCommand
     public function __construct(
         Factory $factory,
         Normalizer\NormalizerInterface $normalizer,
-        Normalizer\Format\FormatterInterface $formatter = null,
-        Diff\Differ $differ = null
+        Normalizer\Format\FormatterInterface $formatter,
+        Diff\Differ $differ
     ) {
         parent::__construct('normalize');
 
         $this->factory = $factory;
         $this->normalizer = $normalizer;
-        $this->formatter = $formatter ?: new Normalizer\Format\Formatter();
-        $this->differ = $differ ?: new Diff\Differ();
+        $this->formatter = $formatter;
+        $this->differ = $differ;
     }
 
     protected function configure(): void

--- a/src/NormalizePlugin.php
+++ b/src/NormalizePlugin.php
@@ -17,7 +17,9 @@ use Composer\Composer;
 use Composer\Factory;
 use Composer\IO;
 use Composer\Plugin;
-use Localheinz\Composer\Json\Normalizer;
+use Localheinz\Composer\Json\Normalizer\ComposerJsonNormalizer;
+use Localheinz\Json\Normalizer\Format;
+use SebastianBergmann\Diff;
 
 final class NormalizePlugin implements Plugin\PluginInterface, Plugin\Capable, Plugin\Capability\CommandProvider
 {
@@ -49,7 +51,9 @@ final class NormalizePlugin implements Plugin\PluginInterface, Plugin\Capable, P
         return [
             new Command\NormalizeCommand(
                 new Factory(),
-                new Normalizer\ComposerJsonNormalizer()
+                new ComposerJsonNormalizer(),
+                new Format\Formatter(),
+                new Diff\Differ()
             ),
         ];
     }

--- a/test/Unit/Command/NormalizeCommandTest.php
+++ b/test/Unit/Command/NormalizeCommandTest.php
@@ -24,6 +24,7 @@ use Localheinz\Test\Util\Helper;
 use org\bovigo\vfs;
 use PHPUnit\Framework;
 use Prophecy\Argument;
+use SebastianBergmann\Diff;
 use Symfony\Component\Console;
 
 /**
@@ -57,7 +58,9 @@ final class NormalizeCommandTest extends Framework\TestCase
     {
         $command = new NormalizeCommand(
             $this->prophesize(Factory::class)->reveal(),
-            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal()
+            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal(),
+            $this->prophesize(Normalizer\Format\FormatterInterface::class)->reveal(),
+            new Diff\Differ()
         );
 
         $this->assertSame('normalize', $command->getName());
@@ -68,7 +71,9 @@ final class NormalizeCommandTest extends Framework\TestCase
     {
         $command = new NormalizeCommand(
             $this->prophesize(Factory::class)->reveal(),
-            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal()
+            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal(),
+            $this->prophesize(Normalizer\Format\FormatterInterface::class)->reveal(),
+            new Diff\Differ()
         );
 
         $definition = $command->getDefinition();
@@ -86,7 +91,9 @@ final class NormalizeCommandTest extends Framework\TestCase
     {
         $command = new NormalizeCommand(
             $this->prophesize(Factory::class)->reveal(),
-            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal()
+            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal(),
+            $this->prophesize(Normalizer\Format\FormatterInterface::class)->reveal(),
+            new Diff\Differ()
         );
 
         $definition = $command->getDefinition();
@@ -105,7 +112,9 @@ final class NormalizeCommandTest extends Framework\TestCase
     {
         $command = new NormalizeCommand(
             $this->prophesize(Factory::class)->reveal(),
-            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal()
+            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal(),
+            $this->prophesize(Normalizer\Format\FormatterInterface::class)->reveal(),
+            new Diff\Differ()
         );
 
         $definition = $command->getDefinition();
@@ -124,7 +133,9 @@ final class NormalizeCommandTest extends Framework\TestCase
     {
         $command = new NormalizeCommand(
             $this->prophesize(Factory::class)->reveal(),
-            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal()
+            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal(),
+            $this->prophesize(Normalizer\Format\FormatterInterface::class)->reveal(),
+            new Diff\Differ()
         );
 
         $definition = $command->getDefinition();
@@ -149,7 +160,9 @@ final class NormalizeCommandTest extends Framework\TestCase
     {
         $command = new NormalizeCommand(
             $this->prophesize(Factory::class)->reveal(),
-            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal()
+            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal(),
+            $this->prophesize(Normalizer\Format\FormatterInterface::class)->reveal(),
+            new Diff\Differ()
         );
 
         $definition = $command->getDefinition();
@@ -181,7 +194,9 @@ final class NormalizeCommandTest extends Framework\TestCase
 
         $command = new NormalizeCommand(
             $this->prophesize(Factory::class)->reveal(),
-            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal()
+            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal(),
+            $this->prophesize(Normalizer\Format\FormatterInterface::class)->reveal(),
+            new Diff\Differ()
         );
 
         $command->setIO($io->reveal());
@@ -212,7 +227,9 @@ final class NormalizeCommandTest extends Framework\TestCase
 
         $command = new NormalizeCommand(
             $this->prophesize(Factory::class)->reveal(),
-            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal()
+            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal(),
+            $this->prophesize(Normalizer\Format\FormatterInterface::class)->reveal(),
+            new Diff\Differ()
         );
 
         $command->setIO($io->reveal());
@@ -256,7 +273,9 @@ final class NormalizeCommandTest extends Framework\TestCase
 
         $command = new NormalizeCommand(
             $this->prophesize(Factory::class)->reveal(),
-            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal()
+            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal(),
+            $this->prophesize(Normalizer\Format\FormatterInterface::class)->reveal(),
+            new Diff\Differ()
         );
 
         $command->setIO($io->reveal());
@@ -312,7 +331,9 @@ final class NormalizeCommandTest extends Framework\TestCase
 
         $command = new NormalizeCommand(
             $this->prophesize(Factory::class)->reveal(),
-            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal()
+            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal(),
+            $this->prophesize(Normalizer\Format\FormatterInterface::class)->reveal(),
+            new Diff\Differ()
         );
 
         $command->setIO($io->reveal());
@@ -357,7 +378,9 @@ final class NormalizeCommandTest extends Framework\TestCase
 
         $command = new NormalizeCommand(
             $factory->reveal(),
-            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal()
+            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal(),
+            $this->prophesize(Normalizer\Format\FormatterInterface::class)->reveal(),
+            new Diff\Differ()
         );
 
         $command->setIO($io->reveal());
@@ -402,7 +425,9 @@ final class NormalizeCommandTest extends Framework\TestCase
 
         $command = new NormalizeCommand(
             $factory->reveal(),
-            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal()
+            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal(),
+            $this->prophesize(Normalizer\Format\FormatterInterface::class)->reveal(),
+            new Diff\Differ()
         );
 
         $command->setIO($io->reveal());
@@ -463,7 +488,9 @@ final class NormalizeCommandTest extends Framework\TestCase
 
         $command = new NormalizeCommand(
             $factory->reveal(),
-            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal()
+            $this->prophesize(Normalizer\NormalizerInterface::class)->reveal(),
+            $this->prophesize(Normalizer\Format\FormatterInterface::class)->reveal(),
+            new Diff\Differ()
         );
 
         $command->setIO($io->reveal());


### PR DESCRIPTION
This PR

* [x] stops ignoring errors related to method arguments with default values
* [x] requires arguments to be passed via constructor into `NormalizeCommand`

Follows #113. 
Follows #115.