### PR TITLE
Fix: Do not self-update composer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,5 @@ test: vendor
 	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml
 
 vendor: composer.json composer.lock
-	composer self-update
 	composer validate
 	composer install


### PR DESCRIPTION
This PR

* [x] stops updating `composer` itself in the `vendor` target

💁‍♂️ Appears that `sudo` is required, and otherwise the following happens:

![screen shot 2018-12-09 at 12 58 37](https://user-images.githubusercontent.com/605483/49696978-2a771d80-fbb2-11e8-9cf4-971eca2c68da.png)
