### PR TITLE
Fix: Configure temporary directory for phpstan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,3 +11,4 @@ parameters:
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$differ with null as default value.#'
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$formatter with null as default value.#'
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::indentFrom\(\) has a nullable return type declaration.#'
+	tmpDir: %currentWorkingDirectory%/.phpstan


### PR DESCRIPTION
This PR

* [x] configures the temporary directory for `phpstan`

Follows #126.
Follows #127.