### PR TITLE
Fix: Properly invoke update command when needed after normalization 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ jobs:
         - mkdir -p $HOME/.infection
 
       script:
-        - vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=100 --min-msi=70
+        - vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=100 --min-msi=71
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ cs: vendor
 
 infection: vendor
 	mkdir -p .infection
-	vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=100 --min-msi=70
+	vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=100 --min-msi=71
 
 stan: vendor
 	mkdir -p .phpstan

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -370,7 +370,7 @@ final class NormalizeCommand extends Command\BaseCommand
     {
         return $this->getApplication()->run(
             new Console\Input\ArrayInput([
-                'update' => 'validate',
+                'command' => 'update',
                 '--lock' => true,
                 '--no-autoloader' => true,
                 '--no-plugins' => true,


### PR DESCRIPTION
This PR

* [x] asserts that the command succeeds when `composer.lock` is present and fresh before normalization and `composer.json` is not yet normalized
* [x] properly invokes the `update` command

Follows #109.
Follows #129.