### PR TITLE
Fix: Remove dependency on composer.lock when caching composer cache on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ environment:
       WITH_HIGHEST: true
 
 cache:
-  - '%LOCALAPPDATA%\Composer\files -> composer.lock'
+  - '%LOCALAPPDATA%\Composer\files'
 
 init:
   - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%


### PR DESCRIPTION
This PR

* [x] removes the dependency on `composer.lock` when caching composer cache on AppVeyor

💁‍♂️ Not sure if it helps, but it appears that AppVeyor doesn't actually use the composer cache.