### PR TITLE
Fix: Increase composer memory limit on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ cache:
 
 init:
   - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
+  - SET COMPOSER_MEMORY_LIMIT=-1
   - SET COMPOSER_NO_INTERACTION=1
   - SET PHP=1
   - SET ANSICON=121x90 (121x90)


### PR DESCRIPTION
This PR

* [x] attempts to increase the composer memory limit on AppVeyor

Fixes #137.

💁‍♂️ For reference, see https://getcomposer.org/doc/03-cli.md#composer-memory-limit.