### PR TITLE
Fix: Update locker when locker is not fresh after normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ For a full diff see [`0.9.0...1.0.0`](https://github.com/localheinz/composer-nor
 
 * Added this changelog ([#94](https://github.com/localheinz/composer-normalize/pull/94)), by [@localheinz](https://github.com/localheinz)
 
+#### Fixed
+
+* Force reading `composer.json` and `composer.lock` after normalization to ensure `composer.lock` is updated when not fresh after normalization ([#139](https://github.com/localheinz/composer-normalize/pull/139)), by [@localheinz](https://github.com/localheinz)
+
 #### Removed
 
 * Removed normalizers after extracting package [`localheinz/composer-json-normalizer`](https://github.com/localheinz/composer-json-normalizer) ([#106](https://github.com/localheinz/composer-normalize/pull/106)), by [@localheinz](https://github.com/localheinz)

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -238,6 +238,17 @@ final class NormalizeCommand extends Command\BaseCommand
         if (false === $noUpdateLock && true === $locker->isLocked()) {
             $io->write('<info>Updating lock file.</info>');
 
+            $this->resetComposer();
+
+            $file = $input->getArgument('file');
+
+            if (\is_string($file)) {
+                return $this->updateLockerInWorkingDirectory(
+                    $output,
+                    \dirname($file)
+                );
+            }
+
             return $this->updateLocker($output);
         }
 
@@ -376,6 +387,32 @@ final class NormalizeCommand extends Command\BaseCommand
                 '--no-plugins' => true,
                 '--no-scripts' => true,
                 '--no-suggest' => true,
+            ]),
+            $output
+        );
+    }
+
+    /**
+     * @see https://getcomposer.org/doc/03-cli.md#update
+     *
+     * @param Console\Output\OutputInterface $output
+     * @param string                         $workingDirectory
+     *
+     * @throws \Exception
+     *
+     * @return int
+     */
+    private function updateLockerInWorkingDirectory(Console\Output\OutputInterface $output, string $workingDirectory): int
+    {
+        return $this->getApplication()->run(
+            new Console\Input\ArrayInput([
+                'command' => 'update',
+                '--lock' => true,
+                '--no-autoloader' => true,
+                '--no-plugins' => true,
+                '--no-scripts' => true,
+                '--no-suggest' => true,
+                '--working-dir' => $workingDirectory,
             ]),
             $output
         );


### PR DESCRIPTION
This PR

* [x] asserts that `composer.lock` is updated after normalization
* [x] resets composer after normalization
* [x] passes `--working-dir` option when updating locker and `file` argument was specified

Fixes #98.