### PR TITLE
Fix: Deprecate the file argument

### DIFF
--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -70,7 +70,7 @@ final class NormalizeCommand extends Command\BaseCommand
             new Console\Input\InputArgument(
                 'file',
                 Console\Input\InputArgument::OPTIONAL,
-                'Path to composer.json file'
+                'Path to composer.json file (deprecated, use --working-dir instead)'
             ),
             new Console\Input\InputOption(
                 'dry-run',
@@ -123,6 +123,8 @@ final class NormalizeCommand extends Command\BaseCommand
 
         if (null === $composerFile) {
             $composerFile = Factory::getComposerFile();
+        } else {
+            $io->write('<fg=yellow>Note: The file argument is deprecated and will be removed in 2.0.0. Please use the --working-dir option instead.</fg>');
         }
 
         try {

--- a/test/Integration/NormalizeTest.php
+++ b/test/Integration/NormalizeTest.php
@@ -759,6 +759,55 @@ final class NormalizeTest extends Framework\TestCase
         self::assertComposerLockFileFresh($currentState);
     }
 
+    public function testSucceedsWhenComposerJsonIsPresentAndValidAndComposerLockIsPresentAndFreshBeforeAndComposerJsonIsNotYetNormalizedAndComposerLockIsNotFreshAfterAndInformsWhenFileArgumentIsUsed(): void
+    {
+        $scenario = $this->createScenario(
+            CommandInvocation::usingFileArgument(),
+            __DIR__ . '/../Fixture/json/valid/lock/present/lock/fresh-before/json/not-yet-normalized/lock/not-fresh-after'
+        );
+
+        $initialState = $scenario->initialState();
+
+        self::assertComposerJsonFileExists($initialState);
+        self::assertComposerLockFileExists($initialState);
+        self::assertComposerLockFileFresh($initialState);
+
+        $application = $this->createApplication(new NormalizeCommand(
+            new Factory(),
+            new ComposerJsonNormalizer(),
+            new Formatter(),
+            new Differ()
+        ));
+
+        $input = new Console\Input\ArrayInput($scenario->consoleParameters());
+
+        $output = new Console\Output\BufferedOutput();
+
+        $exitCode = $application->run(
+            $input,
+            $output
+        );
+
+        self::assertExitCodeSame(0, $exitCode);
+
+        $renderedOutput = $output->fetch();
+
+        self::assertContains('Note: The file argument is deprecated and will be removed in 2.0.0. Please use the --working-dir option instead.', $renderedOutput);
+
+        $expected = \sprintf(
+            'Successfully normalized %s.',
+            $scenario->composerJsonFileReference()
+        );
+
+        self::assertContains($expected, $renderedOutput);
+
+        $currentState = $scenario->currentState();
+
+        self::assertComposerJsonFileModified($initialState, $currentState);
+        self::assertComposerLockFileModified($initialState, $currentState);
+        self::assertComposerLockFileFresh($currentState);
+    }
+
     /**
      * @dataProvider providerCommandInvocation
      *

--- a/test/Util/CommandInvocation.php
+++ b/test/Util/CommandInvocation.php
@@ -30,6 +30,11 @@ final class CommandInvocation
         return new self('in-current-working-directory');
     }
 
+    /**
+     * @deprecated The file argument will be removed in 2.0.0.
+     *
+     * @return CommandInvocation
+     */
     public static function usingFileArgument(): self
     {
         return new self('using-file-argument');


### PR DESCRIPTION
This PR

* [x] deprecates the `file` argument

Fixes #144.