### PR TITLE
Fix: Remove the file argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ For a full diff see [`1.x...master`](https://github.com/localheinz/composer-norm
 
 * The constructor of `NormalizeCommand` now requires an implementation of `Localheinz\Json\Normalizer\Format\FormatterInterface`, as well as an instance of `Sebastian\Diff\Differ` to be injected ([#118](https://github.com/localheinz/composer-normalize/pull/118)), by [@localheinz](https://github.com/localheinz)
 
+#### Removed
+
+* Removed the `file` argument of the `NormalizeCommand` as the same functionality can be achieved using the `--working-dir` option ([#151](https://github.com/localheinz/composer-normalize/pull/151)), by [@localheinz](https://github.com/localheinz)
+
 ## `1.x`
 
 ### Unreleased

--- a/README.md
+++ b/README.md
@@ -62,10 +62,6 @@ The `NormalizeCommand` provided by the `NormalizePlugin` within this package wil
 :bulb: Interested in what `ComposerJsonNormalizer` does? Head over to
 [`localheinz/composer-json-normalizer`](https://github.com/localheinz/composer-json-normalizer#normalizers) for a full explanation, or take a look at the [examples](https://github.com/localheinz/composer-normalize#examples)
 
-### Arguments
-
-* `file`: Path to composer.json file (optional, defaults to `composer.json` in working directory)
-
 ### Options
 
 * `--dry-run`: Show the results of normalizing, but do not modify any files

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -67,11 +67,6 @@ final class NormalizeCommand extends Command\BaseCommand
     {
         $this->setDescription('Normalizes composer.json according to its JSON schema (https://getcomposer.org/schema.json).');
         $this->setDefinition([
-            new Console\Input\InputArgument(
-                'file',
-                Console\Input\InputArgument::OPTIONAL,
-                'Path to composer.json file (deprecated, use --working-dir instead)'
-            ),
             new Console\Input\InputOption(
                 'dry-run',
                 null,
@@ -117,13 +112,7 @@ final class NormalizeCommand extends Command\BaseCommand
             return 1;
         }
 
-        $composerFile = $input->getArgument('file');
-
-        if (null === $composerFile) {
-            $composerFile = Factory::getComposerFile();
-        } else {
-            $io->write('<fg=yellow>Note: The file argument is deprecated and will be removed in 2.0.0. Please use the --working-dir option instead.</fg>');
-        }
+        $composerFile = Factory::getComposerFile();
 
         try {
             $composer = $this->factory->createComposer(
@@ -240,15 +229,6 @@ final class NormalizeCommand extends Command\BaseCommand
         $io->write('<info>Updating lock file.</info>');
 
         $this->resetComposer();
-
-        $file = $input->getArgument('file');
-
-        if (\is_string($file)) {
-            return $this->updateLockerInWorkingDirectory(
-                $output,
-                \dirname($file)
-            );
-        }
 
         return $this->updateLocker($output);
     }
@@ -385,32 +365,6 @@ final class NormalizeCommand extends Command\BaseCommand
                 '--no-plugins' => true,
                 '--no-scripts' => true,
                 '--no-suggest' => true,
-            ]),
-            $output
-        );
-    }
-
-    /**
-     * @see https://getcomposer.org/doc/03-cli.md#update
-     *
-     * @param Console\Output\OutputInterface $output
-     * @param string                         $workingDirectory
-     *
-     * @throws \Exception
-     *
-     * @return int
-     */
-    private function updateLockerInWorkingDirectory(Console\Output\OutputInterface $output, string $workingDirectory): int
-    {
-        return $this->getApplication()->run(
-            new Console\Input\ArrayInput([
-                'command' => 'update',
-                '--lock' => true,
-                '--no-autoloader' => true,
-                '--no-plugins' => true,
-                '--no-scripts' => true,
-                '--no-suggest' => true,
-                '--working-dir' => $workingDirectory,
             ]),
             $output
         );

--- a/test/Integration/NormalizeTest.php
+++ b/test/Integration/NormalizeTest.php
@@ -360,13 +360,7 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-
-        $expected = \sprintf(
-            '%s is already normalized.',
-            $scenario->composerJsonFileReference()
-        );
-
-        self::assertContains($expected, $output->fetch());
+        self::assertContains('./composer.json is already normalized.', $output->fetch());
         self::assertEquals($initialState, $scenario->currentState());
     }
 
@@ -404,13 +398,7 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-
-        $expected = \sprintf(
-            'Successfully normalized %s.',
-            $scenario->composerJsonFileReference()
-        );
-
-        self::assertContains($expected, $output->fetch());
+        self::assertContains('Successfully normalized ./composer.json.', $output->fetch());
 
         $currentState = $scenario->currentState();
 
@@ -457,12 +445,7 @@ final class NormalizeTest extends Framework\TestCase
 
         $renderedOutput = $output->fetch();
 
-        $expected = \sprintf(
-            '%s is not normalized.',
-            $scenario->composerJsonFileReference()
-        );
-
-        self::assertContains($expected, $renderedOutput);
+        self::assertContains('./composer.json is not normalized.', $renderedOutput);
         self::assertContains('--- original', $renderedOutput);
         self::assertContains('+++ normalized', $renderedOutput);
         self::assertContains('---------- begin diff ----------', $renderedOutput);
@@ -512,13 +495,7 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-
-        $expected = \sprintf(
-            'Successfully normalized %s.',
-            $scenario->composerJsonFileReference()
-        );
-
-        self::assertContains($expected, $output->fetch());
+        self::assertContains('Successfully normalized ./composer.json.', $output->fetch());
 
         $currentState = $scenario->currentState();
 
@@ -562,13 +539,7 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-
-        $expected = \sprintf(
-            'Successfully normalized %s.',
-            $scenario->composerJsonFileReference()
-        );
-
-        self::assertContains($expected, $output->fetch());
+        self::assertContains('Successfully normalized ./composer.json.', $output->fetch());
 
         $currentState = $scenario->currentState();
 
@@ -650,13 +621,7 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-
-        $expected = \sprintf(
-            '%s is already normalized.',
-            $scenario->composerJsonFileReference()
-        );
-
-        self::assertContains($expected, $output->fetch());
+        self::assertContains('./composer.json is already normalized.', $output->fetch());
         self::assertEquals($initialState, $scenario->currentState());
     }
 
@@ -695,13 +660,7 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-
-        $expected = \sprintf(
-            'Successfully normalized %s.',
-            $scenario->composerJsonFileReference()
-        );
-
-        self::assertContains($expected, $output->fetch());
+        self::assertContains('Successfully normalized ./composer.json.', $output->fetch());
 
         $currentState = $scenario->currentState();
 
@@ -744,62 +703,7 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-
-        $expected = \sprintf(
-            'Successfully normalized %s.',
-            $scenario->composerJsonFileReference()
-        );
-
-        self::assertContains($expected, $output->fetch());
-
-        $currentState = $scenario->currentState();
-
-        self::assertComposerJsonFileModified($initialState, $currentState);
-        self::assertComposerLockFileModified($initialState, $currentState);
-        self::assertComposerLockFileFresh($currentState);
-    }
-
-    public function testSucceedsWhenComposerJsonIsPresentAndValidAndComposerLockIsPresentAndFreshBeforeAndComposerJsonIsNotYetNormalizedAndComposerLockIsNotFreshAfterAndInformsWhenFileArgumentIsUsed(): void
-    {
-        $scenario = $this->createScenario(
-            CommandInvocation::usingFileArgument(),
-            __DIR__ . '/../Fixture/json/valid/lock/present/lock/fresh-before/json/not-yet-normalized/lock/not-fresh-after'
-        );
-
-        $initialState = $scenario->initialState();
-
-        self::assertComposerJsonFileExists($initialState);
-        self::assertComposerLockFileExists($initialState);
-        self::assertComposerLockFileFresh($initialState);
-
-        $application = $this->createApplication(new NormalizeCommand(
-            new Factory(),
-            new ComposerJsonNormalizer(),
-            new Formatter(),
-            new Differ()
-        ));
-
-        $input = new Console\Input\ArrayInput($scenario->consoleParameters());
-
-        $output = new Console\Output\BufferedOutput();
-
-        $exitCode = $application->run(
-            $input,
-            $output
-        );
-
-        self::assertExitCodeSame(0, $exitCode);
-
-        $renderedOutput = $output->fetch();
-
-        self::assertContains('Note: The file argument is deprecated and will be removed in 2.0.0. Please use the --working-dir option instead.', $renderedOutput);
-
-        $expected = \sprintf(
-            'Successfully normalized %s.',
-            $scenario->composerJsonFileReference()
-        );
-
-        self::assertContains($expected, $renderedOutput);
+        self::assertContains('Successfully normalized ./composer.json.', $output->fetch());
 
         $currentState = $scenario->currentState();
 
@@ -847,12 +751,7 @@ final class NormalizeTest extends Framework\TestCase
 
         $renderedOutput = $output->fetch();
 
-        $expected = \sprintf(
-            '%s is not normalized.',
-            $scenario->composerJsonFileReference()
-        );
-
-        self::assertContains($expected, $renderedOutput);
+        self::assertContains('./composer.json is not normalized.', $renderedOutput);
         self::assertContains('---------- begin diff ----------', $renderedOutput);
         self::assertContains('----------- end diff -----------', $renderedOutput);
         self::assertEquals($initialState, $scenario->currentState());
@@ -895,13 +794,7 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-
-        $expected = \sprintf(
-            'Successfully normalized %s.',
-            $scenario->composerJsonFileReference()
-        );
-
-        self::assertContains($expected, $output->fetch());
+        self::assertContains('Successfully normalized ./composer.json.', $output->fetch());
 
         $currentState = $scenario->currentState();
 
@@ -1031,7 +924,6 @@ final class NormalizeTest extends Framework\TestCase
     {
         return [
             CommandInvocation::inCurrentWorkingDirectory(),
-            CommandInvocation::usingFileArgument(),
             CommandInvocation::usingWorkingDirectoryOption(),
         ];
     }

--- a/test/Util/Scenario.php
+++ b/test/Util/Scenario.php
@@ -102,16 +102,4 @@ final class Scenario
 
         return $parameters;
     }
-
-    public function composerJsonFileReference(): string
-    {
-        if ($this->commandInvocation->is(CommandInvocation::usingFileArgument())) {
-            return \sprintf(
-                '%s/composer.json',
-                $this->initialState->directory()->path()
-            );
-        }
-
-        return './composer.json';
-    }
 }


### PR DESCRIPTION
This PR

* [x] removes the `file` argument

Fixes #143.