### PR TITLE
Enhancement: Require phpstan/phpstan-deprecation-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "localheinz/phpstan-rules": "~0.5.0",
     "localheinz/test-util": "0.6.1",
     "phpstan/phpstan": "~0.10.7",
+    "phpstan/phpstan-deprecation-rules": "~0.10.2",
     "phpstan/phpstan-strict-rules": "~0.10.1",
     "phpunit/phpunit": "^6.5.13 || ^7.5.0",
     "symfony/filesystem": "^4.2.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc716dd8f5b68ca8da83d15a9c9caccf",
+    "content-hash": "dafab01228101ed3c2213db9d5a617f9",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2882,6 +2882,52 @@
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "time": "2018-12-28T13:47:37+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "0.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "fc7d373a760d2bf5cf999b052072adfa728892a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/fc7d373a760d2bf5cf999b052072adfa728892a0",
+                "reference": "fc7d373a760d2bf5cf999b052072adfa728892a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.0",
+                "php": "~7.1",
+                "phpstan/phpstan": "^0.10"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.0.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "phing/phing": "^2.16.0",
+                "phpstan/phpstan-phpunit": "^0.10",
+                "phpunit/phpunit": "^7.0",
+                "slevomat/coding-standard": "^4.5.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "time": "2018-06-30T14:42:51+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 includes:
 	- vendor/jangregor/phpstan-prophecy/src/extension.neon
 	- vendor/localheinz/phpstan-rules/rules.neon
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
 	- vendor/phpstan/phpstan/conf/config.levelmax.neon
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,7 @@ includes:
 
 parameters:
 	ignoreErrors:
+		- '#Call to deprecated method usingFileArgument\(\) of class Localheinz\\Composer\\Normalize\\Test\\Util\\CommandInvocation.#'
 		- '#Constructor in Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand has parameter \$differ with default value.#'
 		- '#Constructor in Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand has parameter \$formatter with default value.#'
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$differ with null as default value.#'


### PR DESCRIPTION
This PR

* [x] requires `phpstan/phpstan-deprecation-rules`
* [x] includes `rules.neon` from `phpstan/phpstan-deprecation-rules`
* [x] ignores an error involving a deprecated test method
