### PR TITLE
Fix: Remove unused test facilities related to removed file argument

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,7 +9,6 @@ parameters:
 	classesAllowedToBeExtended:
 		- Composer\Command\BaseCommand
 	ignoreErrors:
-		- '#Call to deprecated method usingFileArgument\(\) of class Localheinz\\Composer\\Normalize\\Test\\Util\\CommandInvocation.#'
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::indentFrom\(\) has a nullable return type declaration.#'
 	paths:
 		- src

--- a/test/Util/CommandInvocation.php
+++ b/test/Util/CommandInvocation.php
@@ -30,16 +30,6 @@ final class CommandInvocation
         return new self('in-current-working-directory');
     }
 
-    /**
-     * @deprecated The file argument will be removed in 2.0.0.
-     *
-     * @return CommandInvocation
-     */
-    public static function usingFileArgument(): self
-    {
-        return new self('using-file-argument');
-    }
-
     public static function usingWorkingDirectoryOption(): self
     {
         return new self('using-working-directory-option');

--- a/test/Util/Scenario.php
+++ b/test/Util/Scenario.php
@@ -85,15 +85,6 @@ final class Scenario
             'command' => 'normalize',
         ];
 
-        if ($this->commandInvocation->is(CommandInvocation::usingFileArgument())) {
-            return \array_merge($parameters, [
-                'file' => \sprintf(
-                    '%s/composer.json',
-                    $this->initialState->directory()->path()
-                ),
-            ]);
-        }
-
         if ($this->commandInvocation->is(CommandInvocation::usingWorkingDirectoryOption())) {
             return \array_merge($parameters, [
                 '--working-dir' => $this->initialState->directory()->path(),


### PR DESCRIPTION
This PR

* [x] removes unused test facilities related to previously removed `file` argument

Related to #143.
Follows #151.
