### PR TITLE
Fix: Revert deprecation of file argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Unreleased
 
-For a full diff see [`1.1.1...1.x`](https://github.com/localheinz/composer-normalize/compare/1.1.1...1.x).
+For a full diff see [`1.1.2...1.x`](https://github.com/localheinz/composer-normalize/compare/1.1.2...1.x).
+
+### [`1.1.2`](https://github.com/localheinz/composer-normalize/releases/tag/1.1.2)
+
+For a full diff see [`1.1.1...1.1.2`](https://github.com/localheinz/composer-normalize/compare/1.1.1...1.1.2).
+
+#### Fixed
+
+* Reverted deprecation of the `file` argument of the `NormalizeCommand` as it turns out that the same functionality can _not_ be achieved using the `--working-dir` option ([#166](https://github.com/localheinz/composer-normalize/pull/166)), by [@localheinz](https://github.com/localheinz)
 
 ### [`1.1.1`](https://github.com/localheinz/composer-normalize/releases/tag/1.1.1)
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,7 +9,6 @@ parameters:
 	classesAllowedToBeExtended:
 		- Composer\Command\BaseCommand
 	ignoreErrors:
-		- '#Call to deprecated method usingFileArgument\(\) of class Localheinz\\Composer\\Normalize\\Test\\Util\\CommandInvocation.#'
 		- '#Constructor in Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand has parameter \$differ with default value.#'
 		- '#Constructor in Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand has parameter \$formatter with default value.#'
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$differ with null as default value.#'

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -70,7 +70,7 @@ final class NormalizeCommand extends Command\BaseCommand
             new Console\Input\InputArgument(
                 'file',
                 Console\Input\InputArgument::OPTIONAL,
-                'Path to composer.json file (deprecated, use --working-dir instead)'
+                'Path to composer.json file'
             ),
             new Console\Input\InputOption(
                 'dry-run',
@@ -121,8 +121,6 @@ final class NormalizeCommand extends Command\BaseCommand
 
         if (null === $composerFile) {
             $composerFile = Factory::getComposerFile();
-        } else {
-            $io->write('<fg=yellow>Note: The file argument is deprecated and will be removed in 2.0.0. Please use the --working-dir option instead.</fg>');
         }
 
         try {

--- a/test/Integration/NormalizeTest.php
+++ b/test/Integration/NormalizeTest.php
@@ -759,55 +759,6 @@ final class NormalizeTest extends Framework\TestCase
         self::assertComposerLockFileFresh($currentState);
     }
 
-    public function testSucceedsWhenComposerJsonIsPresentAndValidAndComposerLockIsPresentAndFreshBeforeAndComposerJsonIsNotYetNormalizedAndComposerLockIsNotFreshAfterAndInformsWhenFileArgumentIsUsed(): void
-    {
-        $scenario = $this->createScenario(
-            CommandInvocation::usingFileArgument(),
-            __DIR__ . '/../Fixture/json/valid/lock/present/lock/fresh-before/json/not-yet-normalized/lock/not-fresh-after'
-        );
-
-        $initialState = $scenario->initialState();
-
-        self::assertComposerJsonFileExists($initialState);
-        self::assertComposerLockFileExists($initialState);
-        self::assertComposerLockFileFresh($initialState);
-
-        $application = $this->createApplication(new NormalizeCommand(
-            new Factory(),
-            new ComposerJsonNormalizer(),
-            new Formatter(),
-            new Differ()
-        ));
-
-        $input = new Console\Input\ArrayInput($scenario->consoleParameters());
-
-        $output = new Console\Output\BufferedOutput();
-
-        $exitCode = $application->run(
-            $input,
-            $output
-        );
-
-        self::assertExitCodeSame(0, $exitCode);
-
-        $renderedOutput = $output->fetch();
-
-        self::assertContains('Note: The file argument is deprecated and will be removed in 2.0.0. Please use the --working-dir option instead.', $renderedOutput);
-
-        $expected = \sprintf(
-            'Successfully normalized %s.',
-            $scenario->composerJsonFileReference()
-        );
-
-        self::assertContains($expected, $renderedOutput);
-
-        $currentState = $scenario->currentState();
-
-        self::assertComposerJsonFileModified($initialState, $currentState);
-        self::assertComposerLockFileModified($initialState, $currentState);
-        self::assertComposerLockFileFresh($currentState);
-    }
-
     /**
      * @dataProvider providerCommandInvocation
      *

--- a/test/Util/CommandInvocation.php
+++ b/test/Util/CommandInvocation.php
@@ -30,11 +30,6 @@ final class CommandInvocation
         return new self('in-current-working-directory');
     }
 
-    /**
-     * @deprecated The file argument will be removed in 2.0.0.
-     *
-     * @return CommandInvocation
-     */
     public static function usingFileArgument(): self
     {
         return new self('using-file-argument');


### PR DESCRIPTION
This PR

* [x] reverts the deprecation of the `file` argument as it turns out that the same functionality cannot be achieved using the `--working-dir` option

Follows #143. 
Fixes #165.