### PR TITLE
Fix: Revert removal of file argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,6 @@ For a full diff see [`1.x...master`](https://github.com/localheinz/composer-norm
 
 * The constructor of `NormalizeCommand` now requires an implementation of `Localheinz\Json\Normalizer\Format\FormatterInterface`, as well as an instance of `Sebastian\Diff\Differ` to be injected ([#118](https://github.com/localheinz/composer-normalize/pull/118)), by [@localheinz](https://github.com/localheinz)
 
-#### Removed
-
-* Removed the `file` argument of the `NormalizeCommand` as the same functionality can be achieved using the `--working-dir` option ([#151](https://github.com/localheinz/composer-normalize/pull/151)), by [@localheinz](https://github.com/localheinz)
-
 ## `1.x`
 
 ### Unreleased

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ The `NormalizeCommand` provided by the `NormalizePlugin` within this package wil
 :bulb: Interested in what `ComposerJsonNormalizer` does? Head over to
 [`localheinz/composer-json-normalizer`](https://github.com/localheinz/composer-json-normalizer#normalizers) for a full explanation, or take a look at the [examples](https://github.com/localheinz/composer-normalize#examples)
 
+### Arguments
+
+* `file`: Path to composer.json file (optional, defaults to `composer.json` in working directory)
+
 ### Options
 
 * `--dry-run`: Show the results of normalizing, but do not modify any files

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,7 @@ parameters:
 	classesAllowedToBeExtended:
 		- Composer\Command\BaseCommand
 	ignoreErrors:
+		- '#Call to deprecated method usingFileArgument\(\) of class Localheinz\\Composer\\Normalize\\Test\\Util\\CommandInvocation.#'
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::indentFrom\(\) has a nullable return type declaration.#'
 	paths:
 		- src

--- a/test/Integration/NormalizeTest.php
+++ b/test/Integration/NormalizeTest.php
@@ -360,7 +360,13 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-        self::assertContains('./composer.json is already normalized.', $output->fetch());
+
+        $expected = \sprintf(
+            '%s is already normalized.',
+            $scenario->composerJsonFileReference()
+        );
+
+        self::assertContains($expected, $output->fetch());
         self::assertEquals($initialState, $scenario->currentState());
     }
 
@@ -398,7 +404,13 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-        self::assertContains('Successfully normalized ./composer.json.', $output->fetch());
+
+        $expected = \sprintf(
+            'Successfully normalized %s.',
+            $scenario->composerJsonFileReference()
+        );
+
+        self::assertContains($expected, $output->fetch());
 
         $currentState = $scenario->currentState();
 
@@ -445,7 +457,12 @@ final class NormalizeTest extends Framework\TestCase
 
         $renderedOutput = $output->fetch();
 
-        self::assertContains('./composer.json is not normalized.', $renderedOutput);
+        $expected = \sprintf(
+            '%s is not normalized.',
+            $scenario->composerJsonFileReference()
+        );
+
+        self::assertContains($expected, $renderedOutput);
         self::assertContains('--- original', $renderedOutput);
         self::assertContains('+++ normalized', $renderedOutput);
         self::assertContains('---------- begin diff ----------', $renderedOutput);
@@ -495,7 +512,13 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-        self::assertContains('Successfully normalized ./composer.json.', $output->fetch());
+
+        $expected = \sprintf(
+            'Successfully normalized %s.',
+            $scenario->composerJsonFileReference()
+        );
+
+        self::assertContains($expected, $output->fetch());
 
         $currentState = $scenario->currentState();
 
@@ -539,7 +562,13 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-        self::assertContains('Successfully normalized ./composer.json.', $output->fetch());
+
+        $expected = \sprintf(
+            'Successfully normalized %s.',
+            $scenario->composerJsonFileReference()
+        );
+
+        self::assertContains($expected, $output->fetch());
 
         $currentState = $scenario->currentState();
 
@@ -621,7 +650,13 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-        self::assertContains('./composer.json is already normalized.', $output->fetch());
+
+        $expected = \sprintf(
+            '%s is already normalized.',
+            $scenario->composerJsonFileReference()
+        );
+
+        self::assertContains($expected, $output->fetch());
         self::assertEquals($initialState, $scenario->currentState());
     }
 
@@ -660,7 +695,13 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-        self::assertContains('Successfully normalized ./composer.json.', $output->fetch());
+
+        $expected = \sprintf(
+            'Successfully normalized %s.',
+            $scenario->composerJsonFileReference()
+        );
+
+        self::assertContains($expected, $output->fetch());
 
         $currentState = $scenario->currentState();
 
@@ -703,7 +744,62 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-        self::assertContains('Successfully normalized ./composer.json.', $output->fetch());
+
+        $expected = \sprintf(
+            'Successfully normalized %s.',
+            $scenario->composerJsonFileReference()
+        );
+
+        self::assertContains($expected, $output->fetch());
+
+        $currentState = $scenario->currentState();
+
+        self::assertComposerJsonFileModified($initialState, $currentState);
+        self::assertComposerLockFileModified($initialState, $currentState);
+        self::assertComposerLockFileFresh($currentState);
+    }
+
+    public function testSucceedsWhenComposerJsonIsPresentAndValidAndComposerLockIsPresentAndFreshBeforeAndComposerJsonIsNotYetNormalizedAndComposerLockIsNotFreshAfterAndInformsWhenFileArgumentIsUsed(): void
+    {
+        $scenario = $this->createScenario(
+            CommandInvocation::usingFileArgument(),
+            __DIR__ . '/../Fixture/json/valid/lock/present/lock/fresh-before/json/not-yet-normalized/lock/not-fresh-after'
+        );
+
+        $initialState = $scenario->initialState();
+
+        self::assertComposerJsonFileExists($initialState);
+        self::assertComposerLockFileExists($initialState);
+        self::assertComposerLockFileFresh($initialState);
+
+        $application = $this->createApplication(new NormalizeCommand(
+            new Factory(),
+            new ComposerJsonNormalizer(),
+            new Formatter(),
+            new Differ()
+        ));
+
+        $input = new Console\Input\ArrayInput($scenario->consoleParameters());
+
+        $output = new Console\Output\BufferedOutput();
+
+        $exitCode = $application->run(
+            $input,
+            $output
+        );
+
+        self::assertExitCodeSame(0, $exitCode);
+
+        $renderedOutput = $output->fetch();
+
+        self::assertContains('Note: The file argument is deprecated and will be removed in 2.0.0. Please use the --working-dir option instead.', $renderedOutput);
+
+        $expected = \sprintf(
+            'Successfully normalized %s.',
+            $scenario->composerJsonFileReference()
+        );
+
+        self::assertContains($expected, $renderedOutput);
 
         $currentState = $scenario->currentState();
 
@@ -751,7 +847,12 @@ final class NormalizeTest extends Framework\TestCase
 
         $renderedOutput = $output->fetch();
 
-        self::assertContains('./composer.json is not normalized.', $renderedOutput);
+        $expected = \sprintf(
+            '%s is not normalized.',
+            $scenario->composerJsonFileReference()
+        );
+
+        self::assertContains($expected, $renderedOutput);
         self::assertContains('---------- begin diff ----------', $renderedOutput);
         self::assertContains('----------- end diff -----------', $renderedOutput);
         self::assertEquals($initialState, $scenario->currentState());
@@ -794,7 +895,13 @@ final class NormalizeTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(0, $exitCode);
-        self::assertContains('Successfully normalized ./composer.json.', $output->fetch());
+
+        $expected = \sprintf(
+            'Successfully normalized %s.',
+            $scenario->composerJsonFileReference()
+        );
+
+        self::assertContains($expected, $output->fetch());
 
         $currentState = $scenario->currentState();
 
@@ -924,6 +1031,7 @@ final class NormalizeTest extends Framework\TestCase
     {
         return [
             CommandInvocation::inCurrentWorkingDirectory(),
+            CommandInvocation::usingFileArgument(),
             CommandInvocation::usingWorkingDirectoryOption(),
         ];
     }

--- a/test/Util/CommandInvocation.php
+++ b/test/Util/CommandInvocation.php
@@ -30,6 +30,16 @@ final class CommandInvocation
         return new self('in-current-working-directory');
     }
 
+    /**
+     * @deprecated The file argument will be removed in 2.0.0.
+     *
+     * @return CommandInvocation
+     */
+    public static function usingFileArgument(): self
+    {
+        return new self('using-file-argument');
+    }
+
     public static function usingWorkingDirectoryOption(): self
     {
         return new self('using-working-directory-option');

--- a/test/Util/Scenario.php
+++ b/test/Util/Scenario.php
@@ -85,6 +85,15 @@ final class Scenario
             'command' => 'normalize',
         ];
 
+        if ($this->commandInvocation->is(CommandInvocation::usingFileArgument())) {
+            return \array_merge($parameters, [
+                'file' => \sprintf(
+                    '%s/composer.json',
+                    $this->initialState->directory()->path()
+                ),
+            ]);
+        }
+
         if ($this->commandInvocation->is(CommandInvocation::usingWorkingDirectoryOption())) {
             return \array_merge($parameters, [
                 '--working-dir' => $this->initialState->directory()->path(),
@@ -92,5 +101,17 @@ final class Scenario
         }
 
         return $parameters;
+    }
+
+    public function composerJsonFileReference(): string
+    {
+        if ($this->commandInvocation->is(CommandInvocation::usingFileArgument())) {
+            return \sprintf(
+                '%s/composer.json',
+                $this->initialState->directory()->path()
+            );
+        }
+
+        return './composer.json';
     }
 }


### PR DESCRIPTION
This PR

* [x] reverts the removal of the `file` argument

Reverts #151.
Reverts #164.
Follows #166.
