### PR TITLE
Fix: Do not require composer.json to be writable when using --dry-run option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Unreleased
 
-For a full diff see [`1.1.3...1.x`](https://github.com/localheinz/composer-normalize/compare/1.1.3...1.x).
+For a full diff see [`1.1.4...1.x`](https://github.com/localheinz/composer-normalize/compare/1.1.4...1.x).
+
+### [`1.1.4`](https://github.com/localheinz/composer-normalize/releases/tag/1.1.4)
+
+For a full diff see [`1.1.3...1.1.4`](https://github.com/localheinz/composer-normalize/compare/1.1.3...1.1.4).
+
+#### Fixed
+
+* Removed requirement for `composer.json` to be writable when using the `--dry-run` option ([#177](https://github.com/localheinz/composer-normalize/pull/177)), by [@localheinz](https://github.com/localheinz)
 
 ### [`1.1.3`](https://github.com/localheinz/composer-normalize/releases/tag/1.1.3)
 

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -137,7 +137,7 @@ final class NormalizeCommand extends Command\BaseCommand
             return 1;
         }
 
-        if (!\is_writable($composerFile)) {
+        if (false === $input->getOption('dry-run') && !\is_writable($composerFile)) {
             $io->writeError(\sprintf(
                 '<error>%s is not writable.</error>',
                 $composerFile


### PR DESCRIPTION
This PR

* [x] removes the requirement for `composer.json` to be writable when using the `--dry-run` option