### PR TITLE
Enhancement: Use StrictUnifiedDiffOutputBuilder when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Unreleased
 
-For a full diff see [`1.1.4...1.x`](https://github.com/localheinz/composer-normalize/compare/1.1.4...1.x).
+For a full diff see [`1.2.0...1.x`](https://github.com/localheinz/composer-normalize/compare/1.2.0...1.x).
+
+### [`1.2.0`](https://github.com/localheinz/composer-normalize/releases/tag/1.2.0)
+
+For a full diff see [`1.1.4...1.2.0`](https://github.com/localheinz/composer-normalize/compare/1.1.4...1.2.0).
+
+#### Changed
+
+* Started using the `StrictUnifiedDiffOutputBuilder` when available to create more condensed diffs when using the `--dry-run` option ([#80](https://github.com/localheinz/composer-normalize/pull/180)), by [@localheinz](https://github.com/localheinz)
 
 ### [`1.1.4`](https://github.com/localheinz/composer-normalize/releases/tag/1.1.4)
 

--- a/test/Integration/Command/NormalizeCommandTest.php
+++ b/test/Integration/Command/NormalizeCommandTest.php
@@ -26,7 +26,6 @@ use Localheinz\Json\Normalizer\Json;
 use Localheinz\Json\Normalizer\NormalizerInterface;
 use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
-use SebastianBergmann\Diff\Differ;
 use Symfony\Component\Console;
 use Symfony\Component\Filesystem;
 
@@ -283,8 +282,7 @@ final class NormalizeCommandTest extends Framework\TestCase
                     throw new \RuntimeException($this->exceptionMessage);
                 }
             },
-            new Formatter(),
-            new Differ()
+            new Formatter()
         ));
 
         $input = new Console\Input\ArrayInput($scenario->consoleParameters());
@@ -900,8 +898,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         return self::createApplication(new NormalizeCommand(
             new Factory(),
             new ComposerJsonNormalizer(),
-            new Formatter(),
-            new Differ()
+            new Formatter()
         ));
     }
 


### PR DESCRIPTION
This PR

* [x] uses the `StrictUnifiedDiffOutputBuilder` (when available) to create more condensed diffs when using the `--dry-run` option

Fixes #179.
