### PR TITLE
Fix: Dependabot configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,12 +9,18 @@ update_configs:
       - "localheinz"
     directory: "/"
     ignored_updates:
-      - match: "composer-plugin-api"
-      - match: "composer/composer"
-      - match: "localheinz/composer-json-normalizer"
-      - match: "localheinz/json-normalizer"
-      - match: "phpunit/phpunit"
-      - match: "sebastian/diff"
+      - match:
+          dependency_name: "composer-plugin-api"
+      - match:
+          dependency_name: "composer/composer"
+      - match:
+          dependency_name: "localheinz/composer-json-normalizer"
+      - match:
+          dependency_name: "localheinz/json-normalizer"
+      - match:
+          dependency_name: "phpunit/phpunit"
+      - match:
+          dependency_name: "sebastian/diff"
     package_manager: "php:composer"
     update_schedule: "live"
     version_requirement_updates: "increase_versions"


### PR DESCRIPTION
This PR

* [x] fixes the previously added configuration for Dependabot

Fixes #193.

🤷‍♂ Could have used the [validator](https://dependabot.com/docs/config-file/validator/), couldn't I?