### PR TITLE
Enhancement: Infer private property types from constructor

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,6 +14,7 @@ parameters:
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$differ with null as default value.#'
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$formatter with null as default value.#'
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::indentFrom\(\) has a nullable return type declaration.#'
+	inferPrivatePropertyTypesFromConstructor: true
 	paths:
 		- src
 		- test


### PR DESCRIPTION
This PR

* [x] enables the `inferPrivatePropertyTypeFromConstructor` parameter for `phpstan/phpstan`

Follows #197.