### PR TITLE
Fix: Add missing uses annotation

### DIFF
--- a/test/Integration/Command/NormalizeCommandTest.php
+++ b/test/Integration/Command/NormalizeCommandTest.php
@@ -34,6 +34,8 @@ use Symfony\Component\Filesystem;
  *
  * @covers \Localheinz\Composer\Normalize\Command\NormalizeCommand
  * @covers \Localheinz\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Localheinz\Composer\Normalize\Command\SchemaUriResolver
  */
 final class NormalizeCommandTest extends Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] adds a missing `@uses` annotation