### PR TITLE
Fix: Do not require non-existent job to complete

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -22,7 +22,6 @@ branches:
           -  "Tests (php7.3, locked)"
           -  "Tests (php7.3, highest)"
           -  "Code Coverage"
-          -  "Mutation Tests"
           -  "codecov/patch"
           -  "codecov/project"
         strict: false


### PR DESCRIPTION
This PR

* [x] removes a job that does not even exist from the list of jobs required to complete