### PR TITLE
Fix: Link to GitHub action on marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ This package is licensed using the MIT License.
 
 ## GitHub Action
 
-`localheinz/composer-normalize` is also available as a [GitHub Action](https://github.com/features/actions) on the [GitHub Marketplace](https://github.com/marketplace), see [`localheinz/composer-normalize-action`](https://github.com/marketplace/actions/localheinz-composer-normalize-action) as well as the corresponding repository [`localheinz/composer-normalize-action`](https://github.com/localheinz/composer-normalize-action).
+`localheinz/composer-normalize` is also available as a [GitHub Action](https://github.com/features/actions) on the [GitHub Marketplace](https://github.com/marketplace), see [`composer-normalize-action`](https://github.com/marketplace/actions/composer-normalize-action) as well as the corresponding repository [`localheinz/composer-normalize-action`](https://github.com/localheinz/composer-normalize-action).
 
 ## Services
 


### PR DESCRIPTION
This PR

* [x] fixes the link to the GitHub action on the marketplace in `README.md`