### PR TITLE
Fix: Link to composer website

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Latest Stable Version](https://poser.pugx.org/localheinz/composer-normalize/v/stable)](https://packagist.org/packages/localheinz/composer-normalize)
 [![Total Downloads](https://poser.pugx.org/localheinz/composer-normalize/downloads)](https://packagist.org/packages/localheinz/composer-normalize)
 
-Provides a composer plugin for normalizing `composer.json`.
+Provides a [`composer`](https://getcomposer.org) plugin for normalizing [`composer.json`](https://getcomposer.org/doc/04-schema.md).
 
 ## Motivation
 


### PR DESCRIPTION
This PR

* [x] links to the `composer` website in `README.md`