### PR TITLE
Fix: Run php-cs-fixer with --dry-run option

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,7 +44,7 @@ jobs:
           args: --dry-run
 
       - name: "Run friendsofphp/php-cs-fixer"
-        run: php7.2 vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --using-cache=no --verbose
+        run: php7.2 vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --dry-run --using-cache=no --verbose
 
   static-code-analysis:
     name: "Static Code Analysis"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,7 +12,9 @@ parameters:
 	ignoreErrors:
 		- '#Constructor in Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand has parameter \$differ with default value.#'
 		- '#Constructor in Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand has parameter \$formatter with default value.#'
+		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$differ with a nullable type declaration.#'
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$differ with null as default value.#'
+		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$formatter with a nullable type declaration.#'
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::__construct\(\) has parameter \$formatter with null as default value.#'
 		- '#Method Localheinz\\Composer\\Normalize\\Command\\NormalizeCommand::indentFrom\(\) has a nullable return type declaration.#'
 	inferPrivatePropertyTypeFromConstructor: true

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -52,8 +52,8 @@ final class NormalizeCommand extends Command\BaseCommand
     public function __construct(
         Factory $factory,
         Normalizer\NormalizerInterface $normalizer,
-        Normalizer\Format\FormatterInterface $formatter = null,
-        Diff\Differ $differ = null
+        ?Normalizer\Format\FormatterInterface $formatter = null,
+        ?Diff\Differ $differ = null
     ) {
         parent::__construct('normalize');
 


### PR DESCRIPTION
This PR

* [x] runs `php-cs-fixer` with the `--dry-run` option
* [x] runs `make cs`
* [x] ignores errors reported via static analysis