### PR TITLE
Fix: Remove protection for master branch

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -26,33 +26,6 @@ branches:
         strict: false
       restrictions: null
 
-  - name: master
-    protection:
-      enforce_admins: false
-      required_pull_request_reviews:
-        dismiss_stale_reviews: true
-        require_code_owner_reviews: true
-        required_approving_review_count: 1
-      required_status_checks:
-        contexts:
-          -  "Coding Standards"
-          -  "Static Code Analysis"
-          -  "Tests (php7.1, lowest)"
-          -  "Tests (php7.1, locked)"
-          -  "Tests (php7.1, highest)"
-          -  "Tests (php7.2, lowest)"
-          -  "Tests (php7.2, locked)"
-          -  "Tests (php7.2, highest)"
-          -  "Tests (php7.3, lowest)"
-          -  "Tests (php7.3, locked)"
-          -  "Tests (php7.3, highest)"
-          -  "Code Coverage"
-          -  "Mutation Tests"
-          -  "codecov/patch"
-          -  "codecov/project"
-        strict: false
-      restrictions: null
-
 labels:
   - name: bug
     color: ee0701


### PR DESCRIPTION
This PR

* [x] removes the protection for the `master` branch