### PR TITLE
Fix: References in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## `1.x`
+## Unreleased
 
-### Unreleased
-
-For a full diff see [`1.3.1...1.x`][1.3.1...1.x]
+For a full diff see [`1.3.1...master`][1.3.1...master]
 
 ### Fixed
 
@@ -19,7 +17,7 @@ For a full diff see [`1.3.1...1.x`][1.3.1...1.x]
 
 For a full diff see [`1.3.0...1.3.1`][1.3.0...1.3.1]
 
-#### Fixed
+### Fixed
 
 * Started using `localheinz/diff` to avoid issues using `sebastian/diff` ([#207]), by [@localheinz]
 
@@ -27,152 +25,152 @@ For a full diff see [`1.3.0...1.3.1`][1.3.0...1.3.1]
 
 For a full diff see [`1.2.0...1.3.0`][1.2.0...1.3.0]
 
-#### Changed
+### Changed
 
 * Resolve local and fall back to remote schema so that command works offline and behind proxies ([#190]), by [@localheinz]
 
-### [`1.2.0`][1.2.0]
+## [`1.2.0`][1.2.0]
 
 For a full diff see [`1.1.4...1.2.0`][1.1.4...1.2.0]
 
-#### Changed
+### Changed
 
 * Started using the `StrictUnifiedDiffOutputBuilder` when available to create more condensed diffs when using the `--dry-run` option ([#80]), by [@localheinz]
 
-### [`1.1.4`][1.1.4]
+## [`1.1.4`][1.1.4]
 
 For a full diff see [`1.1.3...1.1.4`][1.1.3...1.1.4]
 
-#### Fixed
+### Fixed
 
 * Removed requirement for `composer.json` to be writable when using the `--dry-run` option ([#177]), by [@localheinz]
 
-### [`1.1.3`][1.1.3]
+## [`1.1.3`][1.1.3]
 
 For a full diff see [`1.1.2...1.1.3`][1.1.2...1.1.3]
 
-#### Fixed
+### Fixed
 
 * Reversed use of red and green for rendering diff when using the `--dry-run` option ([#173]), by [@TravisCarden]
 
-### [`1.1.2`][1.1.2]
+## [`1.1.2`][1.1.2]
 
 For a full diff see [`1.1.1...1.1.2`][1.1.1...1.1.2]
 
-#### Fixed
+### Fixed
 
 * Reverted deprecation of the `file` argument of the `NormalizeCommand` as it turns out that the same functionality can _not_ be achieved using the `--working-dir` option ([#166]), by [@localheinz]
 
-### [`1.1.1`][1.1.1]
+## [`1.1.1`][1.1.1]
 
 For a full diff see [`1.1.0...1.1.1`][1.1.0...1.1.1]
 
-#### Removed
+### Removed
 
 * Updated [`localheinz/composer-json-normalizer`](http://github.com/localheinz/composer-json-normalizer), which effectively removed a dependency on [`composer/composer`](https://github.com/composer/composer) ([#157]), by [@localheinz]
 
-### [`1.1.0`][1.1.0]
+## [`1.1.0`][1.1.0]
 
 For a full diff see [`1.0.0...1.1.0`][1.0.0...1.1.0]
 
-#### Deprecated
+### Deprecated
 
 * Deprecated the `file` argument of the `NormalizeCommand` as the same functionality can be achieved using the `--working-dir` option ([#145]), by [@localheinz]
 
-#### Fixed
+### Fixed
 
 * Force reading `composer.json` and `composer.lock` after normalization to ensure `composer.lock` is updated when not fresh after normalization ([#139]), by [@localheinz]
 
-### [`1.0.0`][1.0.0]
+## [`1.0.0`][1.0.0]
 
 For a full diff see [`0.9.0...1.0.0`][0.9.0...1.0.0]
 
-#### Added
+### Added
 
 * Added this changelog ([#94]), by [@localheinz]
 
-#### Removed
+### Removed
 
 * Removed normalizers after extracting package [`localheinz/composer-json-normalizer`](https://github.com/localheinz/composer-json-normalizer) ([#106]), by [@localheinz]
 
-### [`0.9.0`][0.9.0]
+## [`0.9.0`][0.9.0]
 
 For a full diff see [`0.8.0...0.9.0`][0.8.0...0.9.0]
 
-#### Changed
+### Changed
 
 * The `ConfigHashNormalizer` now also sorts the `scripts-descriptions` section ([#89]), by [@localheinz]
 
-#### Fixed
+### Fixed
 
 * When validation of `composer.lock` fails prior to normalization, it is now recommended to update the lock file only ([#86]), by [@svenluijten]
 
-### [`0.8.0`][0.8.0]
+## [`0.8.0`][0.8.0]
 
 For a full diff see [`0.7.0...0.8.0`][0.7.0...0.8.0]
 
-#### Changed
+### Changed
 
 * The `ConfigHashNormalizer` now also sorts the `extra` section ([#60]), by [@localheinz]
 
-### [`0.7.0`][0.7.0]
+## [`0.7.0`][0.7.0]
 
 For a full diff see [`0.6.0...0.7.0`][0.6.0...0.7.0]
 
-#### Changed
+### Changed
 
 * Updated `localheinz/json-normalizer`, which now sniffs the new-line character and uses it for printing instead of using `PHP_EOL` ([#62]), by [@localheinz]
 
-### [`0.6.0`][0.6.0]
+## [`0.6.0`][0.6.0]
 
 For a full diff see [`0.5.0...0.6.0`][0.5.0...0.6.0]
 
-#### Added
+### Added
 
 * Added a `file` argument to the `NormalizeCommand`, so the path to `composer.json` can be specified now, ([#51]), by [@localheinz]
 
-### [`0.5.0`][0.5.0]
+## [`0.5.0`][0.5.0]
 
 For a full diff see [`0.4.0...0.5.0`][0.4.0...0.5.0]
 
-#### Changed
+### Changed
 
 * Updated `localheinz/json-normalizer`, which significantly improves the `SchemaNormalizer` employed to do the major normalization of `composer.json` ([#42]), by [@localheinz]
 
-### [`0.4.0`][0.4.0]
+## [`0.4.0`][0.4.0]
 
 For a full diff see [`0.3.0...0.4.0`][0.3.0...0.4.0]
 
-#### Added
+### Added
 
 * Added `--dry-run` option, which allows usage in Continuous Integration systems, as it renders a diff and exits with a non-zero exit code ([#38]), by [@localheinz]
 
-### [`0.3.0`][0.3.0]
+## [`0.3.0`][0.3.0]
 
 For a full diff see [`0.2.0...0.3.0`][0.2.0...0.3.0]
 
-#### Fixed
+### Fixed
 
 * Dropped support for PHP 7.0, which allows proper handling of empty PSR-4 namespace prefixes ([#30]), by [@localheinz]
 
-### [`0.2.0`][0.2.0]
+## [`0.2.0`][0.2.0]
 
 For a full diff see [`0.1.0...0.2.0`][0.1.0...0.2.0]
 
-#### Added
+### Added
 
 * Added `--no-update-lock` option, which allows skipping the update of `composer.lock` after normalization ([#28]), by [@localheinz]
 * Added the `VersionConstraintNormalizer`, which normalizes version constraints ([#18]), by [@localheinz]
 
-#### Fixed
+### Fixed
 
 * Using the `--no-scripts` option when invoking the `UpdateCommand` to update `composer.lock` ([#19]), by [@localheinz]
 
-### [`0.1.0`][0.1.0]
+## [`0.1.0`][0.1.0]
 
 For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 
-#### Added
+### Added
 
 * Added `NormalizeCommand` ([#1]), by [@localheinz]
 * Added `ConfigHashNormalizer`, which sorts entries in the `config` section by key ([#2]), by [@localheinz]
@@ -218,7 +216,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [1.1.4...1.2.0]: https://github.com/localheinz/composer-normalize/compare/1.1.4...1.2.0
 [1.2.0...1.3.0]: https://github.com/localheinz/composer-normalize/compare/1.2.0...1.3.0
 [1.3.0...1.3.1]: https://github.com/localheinz/composer-normalize/compare/1.3.0...1.3.1
-[1.3.1...1.x]: https://github.com/localheinz/composer-normalize/compare/1.3.1...1.x
+[1.3.1...master]: https://github.com/localheinz/composer-normalize/compare/1.3.1...master
 
 [#1]: https://github.com/localheinz/composer-normalize/pull/1
 [#2]: https://github.com/localheinz/composer-normalize/pull/2


### PR DESCRIPTION
This PR

* [x] fixes references in `CHANGELOG.md` after removing the `1.x` branch