### PR TITLE
Fix: Remove default values of $formatter and $differ parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`1.3.1...master`][1.3.1...master]
 ## Changed
 
 * Started using `ergebnis/composer-json-normalizer` instead of `localheinz/composer-json-normalizer`, `ergebnis/json-normalizer` instead of `localheinz/json-normalizer`, and `ergebnis/json-printer` instead of `localheinz/json-printer` ([#261]), by [@localheinz]
+* Removed default values for parameters `$formatter` and `$differ` of `Localheinz\Composer\Normalize\Command\NormalizeCommand`  ([#262]), by [@localheinz]
 
 ### Fixed
 
@@ -252,6 +253,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#207]: https://github.com/localheinz/composer-normalize/pull/207
 [#235]: https://github.com/localheinz/composer-normalize/pull/235
 [#261]: https://github.com/localheinz/composer-normalize/pull/261
+[#262]: https://github.com/localheinz/composer-normalize/pull/262
 
 [@localheinz]: https://github.com/localheinz
 [@svenluijten]: https://github.com/svenluijten

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,36 +3,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Constructor in Localheinz\\\\Composer\\\\Normalize\\\\Command\\\\NormalizeCommand has parameter \\$differ with default value\\.$#"
-			count: 1
-			path: src/Command/NormalizeCommand.php
-
-		-
-			message: "#^Constructor in Localheinz\\\\Composer\\\\Normalize\\\\Command\\\\NormalizeCommand has parameter \\$formatter with default value\\.$#"
-			count: 1
-			path: src/Command/NormalizeCommand.php
-
-		-
-			message: "#^Method Localheinz\\\\Composer\\\\Normalize\\\\Command\\\\NormalizeCommand\\:\\:__construct\\(\\) has parameter \\$differ with a nullable type declaration\\.$#"
-			count: 1
-			path: src/Command/NormalizeCommand.php
-
-		-
-			message: "#^Method Localheinz\\\\Composer\\\\Normalize\\\\Command\\\\NormalizeCommand\\:\\:__construct\\(\\) has parameter \\$differ with null as default value\\.$#"
-			count: 1
-			path: src/Command/NormalizeCommand.php
-
-		-
-			message: "#^Method Localheinz\\\\Composer\\\\Normalize\\\\Command\\\\NormalizeCommand\\:\\:__construct\\(\\) has parameter \\$formatter with a nullable type declaration\\.$#"
-			count: 1
-			path: src/Command/NormalizeCommand.php
-
-		-
-			message: "#^Method Localheinz\\\\Composer\\\\Normalize\\\\Command\\\\NormalizeCommand\\:\\:__construct\\(\\) has parameter \\$formatter with null as default value\\.$#"
-			count: 1
-			path: src/Command/NormalizeCommand.php
-
-		-
 			message: "#^Method Localheinz\\\\Composer\\\\Normalize\\\\Command\\\\NormalizeCommand\\:\\:indentFrom\\(\\) has a nullable return type declaration\\.$#"
 			count: 1
 			path: src/Command/NormalizeCommand.php

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -16,7 +16,6 @@ namespace Localheinz\Composer\Normalize\Command;
 use Composer\Command;
 use Composer\Factory;
 use Ergebnis\Json\Normalizer;
-use Ergebnis\Json\Printer;
 use Localheinz\Diff;
 use Symfony\Component\Console;
 
@@ -53,22 +52,14 @@ final class NormalizeCommand extends Command\BaseCommand
     public function __construct(
         Factory $factory,
         Normalizer\NormalizerInterface $normalizer,
-        ?Normalizer\Format\FormatterInterface $formatter = null,
-        ?Diff\Differ $differ = null
+        Normalizer\Format\FormatterInterface $formatter,
+        Diff\Differ $differ
     ) {
         parent::__construct('normalize');
 
         $this->factory = $factory;
         $this->normalizer = $normalizer;
-        $this->formatter = $formatter ?: new Normalizer\Format\Formatter(new Printer\Printer());
-
-        if (null === $differ) {
-            $differ = new Diff\Differ(new Diff\Output\StrictUnifiedDiffOutputBuilder([
-                'fromFile' => 'original',
-                'toFile' => 'normalized',
-            ]));
-        }
-
+        $this->formatter = $formatter;
         $this->differ = $differ;
     }
 

--- a/src/NormalizePlugin.php
+++ b/src/NormalizePlugin.php
@@ -17,8 +17,10 @@ use Composer\Composer;
 use Composer\Factory;
 use Composer\IO;
 use Composer\Plugin;
-use Ergebnis\Composer\Json\Normalizer;
-use Localheinz\Composer\Normalize\Command\SchemaUriResolver;
+use Ergebnis\Composer\Json\Normalizer\ComposerJsonNormalizer;
+use Ergebnis\Json\Normalizer;
+use Ergebnis\Json\Printer;
+use Localheinz\Diff;
 
 final class NormalizePlugin implements Plugin\Capability\CommandProvider, Plugin\Capable, Plugin\PluginInterface
 {
@@ -38,7 +40,12 @@ final class NormalizePlugin implements Plugin\Capability\CommandProvider, Plugin
         return [
             new Command\NormalizeCommand(
                 new Factory(),
-                new Normalizer\ComposerJsonNormalizer(SchemaUriResolver::resolve())
+                new ComposerJsonNormalizer(Command\SchemaUriResolver::resolve()),
+                new Normalizer\Format\Formatter(new Printer\Printer()),
+                new Diff\Differ(new Diff\Output\StrictUnifiedDiffOutputBuilder([
+                    'fromFile' => 'original',
+                    'toFile' => 'normalized',
+                ]))
             ),
         ];
     }

--- a/test/Integration/Command/NormalizeCommandTest.php
+++ b/test/Integration/Command/NormalizeCommandTest.php
@@ -26,6 +26,7 @@ use Localheinz\Composer\Normalize\Test\Util\CommandInvocation;
 use Localheinz\Composer\Normalize\Test\Util\Directory;
 use Localheinz\Composer\Normalize\Test\Util\Scenario;
 use Localheinz\Composer\Normalize\Test\Util\State;
+use Localheinz\Diff;
 use PHPUnit\Framework;
 use Symfony\Component\Console;
 use Symfony\Component\Filesystem;
@@ -285,7 +286,11 @@ final class NormalizeCommandTest extends Framework\TestCase
                     throw new \RuntimeException($this->exceptionMessage);
                 }
             },
-            new Formatter(new Printer())
+            new Formatter(new Printer()),
+            new Diff\Differ(new Diff\Output\StrictUnifiedDiffOutputBuilder([
+                'fromFile' => 'original',
+                'toFile' => 'normalized',
+            ]))
         ));
 
         $input = new Console\Input\ArrayInput($scenario->consoleParameters());


### PR DESCRIPTION
This PR

* [x] removes default values for parameters `$formatter` and `$differ` of constructor of `Localheinz\Composer\Normalize\Command\NormalizeCommand` 