### PR TITLE
Fix: Rename namespace after move to @ergebnis

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,7 +46,7 @@ jobs:
       - name: "Install locked dependencies with composer"
         run: composer install --no-interaction --no-progress --no-suggest
 
-      - name: "Run localheinz/composer-normalize"
+      - name: "Run ergebnis/composer-normalize"
         uses: docker://localheinz/composer-normalize-action:0.5.2
         with:
           args: --dry-run

--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-normalize
+ * @see https://github.com/ergebnis/composer-normalize
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2018 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/composer-normalize
+@see https://github.com/ergebnis/composer-normalize
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,38 @@ For a full diff see [`1.3.1...master`][1.3.1...master]
 ## Changed
 
 * Started using `ergebnis/composer-json-normalizer` instead of `localheinz/composer-json-normalizer`, `ergebnis/json-normalizer` instead of `localheinz/json-normalizer`, and `ergebnis/json-printer` instead of `localheinz/json-printer` ([#261]), by [@localheinz]
-* Removed default values for parameters `$formatter` and `$differ` of `Localheinz\Composer\Normalize\Command\NormalizeCommand`  ([#262]), by [@localheinz]
+* Removed default values for parameters `$formatter` and `$differ` of `Ergebnis\Composer\Normalize\Command\NormalizeCommand`  ([#262]), by [@localheinz]
+* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#267]), by [@localheinz]
+
+  Run
+
+  ```
+  $ composer remove localheinz/composer-normalize
+  ```
+
+  and
+
+  ```
+  $ composer require ergebnis/composer-normalize
+  ```
+
+  to update.
+
+  Run
+
+  ```
+  $ find . -type f -exec sed -i '.bak' 's/Localheinz\\Composer\\Normalizer/Ergebnis\\Composer\\Normalize/g' {} \;
+  ```
+
+  to replace occurrences of `Localheinz\Composer\Normalize` with `Ergebnis\Composer\Normalize`.
+
+  Run
+
+  ```
+  $ find -type f -name '*.bak' -delete
+  ```
+
+  to delete backup files created in the previous step.
 
 ### Fixed
 
@@ -184,77 +215,79 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 * Added the `BinNormalizer`, which sorts entries in the `bin` section by
 * Added the `ComposerJsonNormalizer`, which composes all of the above normalizers along with the `SchemaNormalizer`, to normalize `composer.json` according to its underlying JSON schema ([#8] and [#10]), by [@localheinz]
 
-[0.1.0]: https://github.com/localheinz/composer-normalize/releases/tag/0.1.0
-[0.2.0]: https://github.com/localheinz/composer-normalize/releases/tag/0.2.0
-[0.3.0]: https://github.com/localheinz/composer-normalize/releases/tag/0.3.0
-[0.4.0]: https://github.com/localheinz/composer-normalize/releases/tag/0.4.0
-[0.5.0]: https://github.com/localheinz/composer-normalize/releases/tag/0.5.0
-[0.6.0]: https://github.com/localheinz/composer-normalize/releases/tag/0.6.0
-[0.7.0]: https://github.com/localheinz/composer-normalize/releases/tag/0.7.0
-[0.8.0]: https://github.com/localheinz/composer-normalize/releases/tag/0.8.0
-[0.9.0]: https://github.com/localheinz/composer-normalize/releases/tag/0.9.0
-[1.0.0]: https://github.com/localheinz/composer-normalize/releases/tag/1.0.0
-[1.1.0]: https://github.com/localheinz/composer-normalize/releases/tag/1.1.0
-[1.1.1]: https://github.com/localheinz/composer-normalize/releases/tag/1.1.1
-[1.1.2]: https://github.com/localheinz/composer-normalize/releases/tag/1.1.2
-[1.1.3]: https://github.com/localheinz/composer-normalize/releases/tag/1.1.3
-[1.1.4]: https://github.com/localheinz/composer-normalize/releases/tag/1.1.4
-[1.2.0]: https://github.com/localheinz/composer-normalize/releases/tag/1.2.0
-[1.3.0]: https://github.com/localheinz/composer-normalize/releases/tag/1.3.0
-[1.3.1]: https://github.com/localheinz/composer-normalize/releases/tag/1.3.1
+[0.1.0]: https://github.com/ergebnis/composer-normalize/releases/tag/0.1.0
+[0.2.0]: https://github.com/ergebnis/composer-normalize/releases/tag/0.2.0
+[0.3.0]: https://github.com/ergebnis/composer-normalize/releases/tag/0.3.0
+[0.4.0]: https://github.com/ergebnis/composer-normalize/releases/tag/0.4.0
+[0.5.0]: https://github.com/ergebnis/composer-normalize/releases/tag/0.5.0
+[0.6.0]: https://github.com/ergebnis/composer-normalize/releases/tag/0.6.0
+[0.7.0]: https://github.com/ergebnis/composer-normalize/releases/tag/0.7.0
+[0.8.0]: https://github.com/ergebnis/composer-normalize/releases/tag/0.8.0
+[0.9.0]: https://github.com/ergebnis/composer-normalize/releases/tag/0.9.0
+[1.0.0]: https://github.com/ergebnis/composer-normalize/releases/tag/1.0.0
+[1.1.0]: https://github.com/ergebnis/composer-normalize/releases/tag/1.1.0
+[1.1.1]: https://github.com/ergebnis/composer-normalize/releases/tag/1.1.1
+[1.1.2]: https://github.com/ergebnis/composer-normalize/releases/tag/1.1.2
+[1.1.3]: https://github.com/ergebnis/composer-normalize/releases/tag/1.1.3
+[1.1.4]: https://github.com/ergebnis/composer-normalize/releases/tag/1.1.4
+[1.2.0]: https://github.com/ergebnis/composer-normalize/releases/tag/1.2.0
+[1.3.0]: https://github.com/ergebnis/composer-normalize/releases/tag/1.3.0
+[1.3.1]: https://github.com/ergebnis/composer-normalize/releases/tag/1.3.1
 
-[81bc3a8...0.1.0]: https://github.com/localheinz/composer-normalize/compare/81bc3a8...0.1.0
-[0.1.0...0.2.0]: https://github.com/localheinz/composer-normalize/compare/0.1.0...0.2.0
-[0.2.0...0.3.0]: https://github.com/localheinz/composer-normalize/compare/0.2.0...0.3.0
-[0.3.0...0.4.0]: https://github.com/localheinz/composer-normalize/compare/0.3.0...0.4.0
-[0.4.0...0.5.0]: https://github.com/localheinz/composer-normalize/compare/0.4.0...0.5.0
-[0.5.0...0.6.0]: https://github.com/localheinz/composer-normalize/compare/0.5.0...0.6.0
-[0.6.0...0.7.0]: https://github.com/localheinz/composer-normalize/compare/0.6.0...0.7.0
-[0.7.0...0.8.0]: https://github.com/localheinz/composer-normalize/compare/0.7.0...0.8.0
-[0.8.0...0.9.0]: https://github.com/localheinz/composer-normalize/compare/0.8.0...0.9.0
-[0.9.0...1.0.0]: https://github.com/localheinz/composer-normalize/compare/0.9.0...1.0.0
-[1.0.0...1.1.0]: https://github.com/localheinz/composer-normalize/compare/1.0.0...1.1.0
-[1.1.0...1.1.1]: https://github.com/localheinz/composer-normalize/compare/1.1.0...1.1.1
-[1.1.1...1.1.2]: https://github.com/localheinz/composer-normalize/compare/1.1.1...1.1.2
-[1.1.2...1.1.3]: https://github.com/localheinz/composer-normalize/compare/1.1.2...1.1.3
-[1.1.3...1.1.4]: https://github.com/localheinz/composer-normalize/compare/1.1.3...1.1.4
-[1.1.4...1.2.0]: https://github.com/localheinz/composer-normalize/compare/1.1.4...1.2.0
-[1.2.0...1.3.0]: https://github.com/localheinz/composer-normalize/compare/1.2.0...1.3.0
-[1.3.0...1.3.1]: https://github.com/localheinz/composer-normalize/compare/1.3.0...1.3.1
-[1.3.1...master]: https://github.com/localheinz/composer-normalize/compare/1.3.1...master
+[81bc3a8...0.1.0]: https://github.com/ergebnis/composer-normalize/compare/81bc3a8...0.1.0
+[0.1.0...0.2.0]: https://github.com/ergebnis/composer-normalize/compare/0.1.0...0.2.0
+[0.2.0...0.3.0]: https://github.com/ergebnis/composer-normalize/compare/0.2.0...0.3.0
+[0.3.0...0.4.0]: https://github.com/ergebnis/composer-normalize/compare/0.3.0...0.4.0
+[0.4.0...0.5.0]: https://github.com/ergebnis/composer-normalize/compare/0.4.0...0.5.0
+[0.5.0...0.6.0]: https://github.com/ergebnis/composer-normalize/compare/0.5.0...0.6.0
+[0.6.0...0.7.0]: https://github.com/ergebnis/composer-normalize/compare/0.6.0...0.7.0
+[0.7.0...0.8.0]: https://github.com/ergebnis/composer-normalize/compare/0.7.0...0.8.0
+[0.8.0...0.9.0]: https://github.com/ergebnis/composer-normalize/compare/0.8.0...0.9.0
+[0.9.0...1.0.0]: https://github.com/ergebnis/composer-normalize/compare/0.9.0...1.0.0
+[1.0.0...1.1.0]: https://github.com/ergebnis/composer-normalize/compare/1.0.0...1.1.0
+[1.1.0...1.1.1]: https://github.com/ergebnis/composer-normalize/compare/1.1.0...1.1.1
+[1.1.1...1.1.2]: https://github.com/ergebnis/composer-normalize/compare/1.1.1...1.1.2
+[1.1.2...1.1.3]: https://github.com/ergebnis/composer-normalize/compare/1.1.2...1.1.3
+[1.1.3...1.1.4]: https://github.com/ergebnis/composer-normalize/compare/1.1.3...1.1.4
+[1.1.4...1.2.0]: https://github.com/ergebnis/composer-normalize/compare/1.1.4...1.2.0
+[1.2.0...1.3.0]: https://github.com/ergebnis/composer-normalize/compare/1.2.0...1.3.0
+[1.3.0...1.3.1]: https://github.com/ergebnis/composer-normalize/compare/1.3.0...1.3.1
+[1.3.1...master]: https://github.com/ergebnis/composer-normalize/compare/1.3.1...master
 
-[#1]: https://github.com/localheinz/composer-normalize/pull/1
-[#2]: https://github.com/localheinz/composer-normalize/pull/2
-[#3]: https://github.com/localheinz/composer-normalize/pull/3
-[#6]: https://github.com/localheinz/composer-normalize/pull/6
-[#8]: https://github.com/localheinz/composer-normalize/pull/8
-[#10]: https://github.com/localheinz/composer-normalize/pull/10
-[#18]: https://github.com/localheinz/composer-normalize/pull/18
-[#19]: https://github.com/localheinz/composer-normalize/pull/19
-[#28]: https://github.com/localheinz/composer-normalize/pull/28
-[#30]: https://github.com/localheinz/composer-normalize/pull/30
-[#38]: https://github.com/localheinz/composer-normalize/pull/38
-[#42]: https://github.com/localheinz/composer-normalize/pull/42
-[#51]: https://github.com/localheinz/composer-normalize/pull/51
-[#60]: https://github.com/localheinz/composer-normalize/pull/60
-[#62]: https://github.com/localheinz/composer-normalize/pull/62
-[#80]: https://github.com/localheinz/composer-normalize/pull/80
-[#86]: https://github.com/localheinz/composer-normalize/pull/86
-[#89]: https://github.com/localheinz/composer-normalize/pull/89
-[#94]: https://github.com/localheinz/composer-normalize/pull/94
-[#106]: https://github.com/localheinz/composer-normalize/pull/106
-[#139]: https://github.com/localheinz/composer-normalize/pull/139
-[#145]: https://github.com/localheinz/composer-normalize/pull/145
-[#157]: https://github.com/localheinz/composer-normalize/pull/157
-[#166]: https://github.com/localheinz/composer-normalize/pull/166
-[#173]: https://github.com/localheinz/composer-normalize/pull/173
-[#177]: https://github.com/localheinz/composer-normalize/pull/177
-[#190]: https://github.com/localheinz/composer-normalize/pull/190
-[#207]: https://github.com/localheinz/composer-normalize/pull/207
-[#235]: https://github.com/localheinz/composer-normalize/pull/235
-[#261]: https://github.com/localheinz/composer-normalize/pull/261
-[#262]: https://github.com/localheinz/composer-normalize/pull/262
+[#1]: https://github.com/ergebnis/composer-normalize/pull/1
+[#2]: https://github.com/ergebnis/composer-normalize/pull/2
+[#3]: https://github.com/ergebnis/composer-normalize/pull/3
+[#6]: https://github.com/ergebnis/composer-normalize/pull/6
+[#8]: https://github.com/ergebnis/composer-normalize/pull/8
+[#10]: https://github.com/ergebnis/composer-normalize/pull/10
+[#18]: https://github.com/ergebnis/composer-normalize/pull/18
+[#19]: https://github.com/ergebnis/composer-normalize/pull/19
+[#28]: https://github.com/ergebnis/composer-normalize/pull/28
+[#30]: https://github.com/ergebnis/composer-normalize/pull/30
+[#38]: https://github.com/ergebnis/composer-normalize/pull/38
+[#42]: https://github.com/ergebnis/composer-normalize/pull/42
+[#51]: https://github.com/ergebnis/composer-normalize/pull/51
+[#60]: https://github.com/ergebnis/composer-normalize/pull/60
+[#62]: https://github.com/ergebnis/composer-normalize/pull/62
+[#80]: https://github.com/ergebnis/composer-normalize/pull/80
+[#86]: https://github.com/ergebnis/composer-normalize/pull/86
+[#89]: https://github.com/ergebnis/composer-normalize/pull/89
+[#94]: https://github.com/ergebnis/composer-normalize/pull/94
+[#106]: https://github.com/ergebnis/composer-normalize/pull/106
+[#139]: https://github.com/ergebnis/composer-normalize/pull/139
+[#145]: https://github.com/ergebnis/composer-normalize/pull/145
+[#157]: https://github.com/ergebnis/composer-normalize/pull/157
+[#166]: https://github.com/ergebnis/composer-normalize/pull/166
+[#173]: https://github.com/ergebnis/composer-normalize/pull/173
+[#177]: https://github.com/ergebnis/composer-normalize/pull/177
+[#190]: https://github.com/ergebnis/composer-normalize/pull/190
+[#207]: https://github.com/ergebnis/composer-normalize/pull/207
+[#235]: https://github.com/ergebnis/composer-normalize/pull/235
+[#261]: https://github.com/ergebnis/composer-normalize/pull/261
+[#262]: https://github.com/ergebnis/composer-normalize/pull/262
+[#267]: https://github.com/ergebnis/composer-normalize/pull/267
 
+[@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz
 [@svenluijten]: https://github.com/svenluijten
 [@TravisCarden]: https://github.com/TravisCarden

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # composer-normalize
 
-[![Continuous Integration](https://github.com/localheinz/composer-normalize/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/composer-normalize/actions)
-[![Code Coverage](https://codecov.io/gh/localheinz/composer-normalize/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/composer-normalize)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/composer-normalize/v/stable)](https://packagist.org/packages/localheinz/composer-normalize)
-[![Total Downloads](https://poser.pugx.org/localheinz/composer-normalize/downloads)](https://packagist.org/packages/localheinz/composer-normalize)
+[![Continuous Integration](https://github.com/ergebnis/composer-normalize/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/composer-normalize/actions)
+[![Code Coverage](https://codecov.io/gh/ergebnis/composer-normalize/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/composer-normalize)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/composer-normalize/v/stable)](https://packagist.org/packages/ergebnis/composer-normalize)
+[![Total Downloads](https://poser.pugx.org/ergebnis/composer-normalize/downloads)](https://packagist.org/packages/ergebnis/composer-normalize)
 
 Provides a [`composer`](https://getcomposer.org) plugin for normalizing [`composer.json`](https://getcomposer.org/doc/04-schema.md).
 
@@ -21,7 +21,7 @@ I certainly have noticed, and rather than
 I decided to build something that structures `composer.json` in an automated
 fashion, but without changing the initial intent.
 
-In my opinion, the advantages of using `localheinz/composer-normalize` are
+In my opinion, the advantages of using `ergebnis/composer-normalize` are
 
 * no need to think (or argue) about where to add a new section
 * no need to think (or argue) about proper formatting
@@ -36,7 +36,7 @@ have written a blog post about [Normalizing composer.json](https://localheinz.co
 Run
 
 ```
-$ composer require --dev localheinz/composer-normalize
+$ composer require --dev ergebnis/composer-normalize
 ```
 
 ## Usage
@@ -59,7 +59,7 @@ The `NormalizeCommand` provided by the `NormalizePlugin` within this package wil
 * update the hash in `composer.lock` if it exists and if an update is necessary
 
 :bulb: Interested in what `ComposerJsonNormalizer` does? Head over to
-[`localheinz/composer-json-normalizer`](https://github.com/localheinz/composer-json-normalizer#normalizers) for a full explanation, or take a look at the [examples](https://github.com/localheinz/composer-normalize#examples)
+[`localheinz/composer-json-normalizer`](https://github.com/localheinz/composer-json-normalizer#normalizers) for a full explanation, or take a look at the [examples](https://github.com/ergebnis/composer-normalize#examples)
 
 ### Arguments
 
@@ -482,8 +482,8 @@ This package is licensed using the MIT License.
 
 ## GitHub Action
 
-`localheinz/composer-normalize` is also available as a [GitHub Action](https://github.com/features/actions) on the [GitHub Marketplace](https://github.com/marketplace), see [`composer-normalize-action`](https://github.com/marketplace/actions/composer-normalize-action) as well as the corresponding repository [`localheinz/composer-normalize-action`](https://github.com/localheinz/composer-normalize-action).
+`ergebnis/composer-normalize` is also available as a [GitHub Action](https://github.com/features/actions) on the [GitHub Marketplace](https://github.com/marketplace), see [`composer-normalize-action`](https://github.com/marketplace/actions/composer-normalize-action) as well as the corresponding repository [`localheinz/composer-normalize-action`](https://github.com/localheinz/composer-normalize-action).
 
 ## Services
 
-`localheinz/composer-normalize` is currently in use by [FlintCI](https://flintci.io), see https://flintci.io/docs#composernormalize.
+`ergebnis/composer-normalize` is currently in use by [FlintCI](https://flintci.io), see https://flintci.io/docs#composernormalize.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "localheinz/composer-normalize",
+  "name": "ergebnis/composer-normalize",
   "type": "composer-plugin",
   "description": "Provides a composer plugin for normalizing composer.json.",
   "keywords": [
@@ -8,7 +8,7 @@
     "normalize",
     "plugin"
   ],
-  "homepage": "https://github.com/localheinz/composer-normalize",
+  "homepage": "https://github.com/ergebnis/composer-normalize",
   "license": "MIT",
   "authors": [
     {
@@ -42,20 +42,20 @@
     "sort-packages": true
   },
   "extra": {
-    "class": "Localheinz\\Composer\\Normalize\\NormalizePlugin"
+    "class": "Ergebnis\\Composer\\Normalize\\NormalizePlugin"
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\Composer\\Normalize\\": "src/"
+      "Ergebnis\\Composer\\Normalize\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\Composer\\Normalize\\Test\\": "test/"
+      "Ergebnis\\Composer\\Normalize\\Test\\": "test/"
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/composer-normalize/issues",
-    "source": "https://github.com/localheinz/composer-normalize"
+    "issues": "https://github.com/ergebnis/composer-normalize/issues",
+    "source": "https://github.com/ergebnis/composer-normalize"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26924bcc505289d89e251d14629159d2",
+    "content-hash": "0a316737b490367bc1533f4ab0544b95",
     "packages": [
         {
             "name": "ergebnis/composer-json-normalizer",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,7 +3,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Localheinz\\\\Composer\\\\Normalize\\\\Command\\\\NormalizeCommand\\:\\:indentFrom\\(\\) has a nullable return type declaration\\.$#"
+			message: "#^Method Ergebnis\\\\Composer\\\\Normalize\\\\Command\\\\NormalizeCommand\\:\\:indentFrom\\(\\) has a nullable return type declaration\\.$#"
 			count: 1
 			path: src/Command/NormalizeCommand.php
 

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-normalize
+ * @see https://github.com/ergebnis/composer-normalize
  */
 
-namespace Localheinz\Composer\Normalize\Command;
+namespace Ergebnis\Composer\Normalize\Command;
 
 use Composer\Command;
 use Composer\Factory;

--- a/src/Command/SchemaUriResolver.php
+++ b/src/Command/SchemaUriResolver.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-normalize
+ * @see https://github.com/ergebnis/composer-normalize
  */
 
-namespace Localheinz\Composer\Normalize\Command;
+namespace Ergebnis\Composer\Normalize\Command;
 
 use Composer\Json;
 

--- a/src/NormalizePlugin.php
+++ b/src/NormalizePlugin.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-normalize
+ * @see https://github.com/ergebnis/composer-normalize
  */
 
-namespace Localheinz\Composer\Normalize;
+namespace Ergebnis\Composer\Normalize;
 
 use Composer\Composer;
 use Composer\Factory;

--- a/test/Integration/Command/NormalizeCommandTest.php
+++ b/test/Integration/Command/NormalizeCommandTest.php
@@ -8,24 +8,24 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-normalize
+ * @see https://github.com/ergebnis/composer-normalize
  */
 
-namespace Localheinz\Composer\Normalize\Test\Integration\Command;
+namespace Ergebnis\Composer\Normalize\Test\Integration\Command;
 
 use Composer\Console\Application;
 use Composer\Factory;
+use Ergebnis\Composer\Normalize\Command\NormalizeCommand;
+use Ergebnis\Composer\Normalize\NormalizePlugin;
+use Ergebnis\Composer\Normalize\Test\Util\CommandInvocation;
+use Ergebnis\Composer\Normalize\Test\Util\Directory;
+use Ergebnis\Composer\Normalize\Test\Util\Scenario;
+use Ergebnis\Composer\Normalize\Test\Util\State;
 use Ergebnis\Json\Normalizer\Format\Formatter;
 use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Json\Normalizer\NormalizerInterface;
 use Ergebnis\Json\Printer\Printer;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Composer\Normalize\Command\NormalizeCommand;
-use Localheinz\Composer\Normalize\NormalizePlugin;
-use Localheinz\Composer\Normalize\Test\Util\CommandInvocation;
-use Localheinz\Composer\Normalize\Test\Util\Directory;
-use Localheinz\Composer\Normalize\Test\Util\Scenario;
-use Localheinz\Composer\Normalize\Test\Util\State;
 use Localheinz\Diff;
 use PHPUnit\Framework;
 use Symfony\Component\Console;
@@ -34,10 +34,10 @@ use Symfony\Component\Filesystem;
 /**
  * @internal
  *
- * @covers \Localheinz\Composer\Normalize\Command\NormalizeCommand
- * @covers \Localheinz\Composer\Normalize\NormalizePlugin
+ * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
+ * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
  *
- * @uses \Localheinz\Composer\Normalize\Command\SchemaUriResolver
+ * @uses \Ergebnis\Composer\Normalize\Command\SchemaUriResolver
  */
 final class NormalizeCommandTest extends Framework\TestCase
 {

--- a/test/Util/CommandInvocation.php
+++ b/test/Util/CommandInvocation.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-normalize
+ * @see https://github.com/ergebnis/composer-normalize
  */
 
-namespace Localheinz\Composer\Normalize\Test\Util;
+namespace Ergebnis\Composer\Normalize\Test\Util;
 
 final class CommandInvocation
 {

--- a/test/Util/Directory.php
+++ b/test/Util/Directory.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-normalize
+ * @see https://github.com/ergebnis/composer-normalize
  */
 
-namespace Localheinz\Composer\Normalize\Test\Util;
+namespace Ergebnis\Composer\Normalize\Test\Util;
 
 final class Directory
 {

--- a/test/Util/File.php
+++ b/test/Util/File.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-normalize
+ * @see https://github.com/ergebnis/composer-normalize
  */
 
-namespace Localheinz\Composer\Normalize\Test\Util;
+namespace Ergebnis\Composer\Normalize\Test\Util;
 
 final class File
 {

--- a/test/Util/Scenario.php
+++ b/test/Util/Scenario.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-normalize
+ * @see https://github.com/ergebnis/composer-normalize
  */
 
-namespace Localheinz\Composer\Normalize\Test\Util;
+namespace Ergebnis\Composer\Normalize\Test\Util;
 
 final class Scenario
 {

--- a/test/Util/State.php
+++ b/test/Util/State.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/composer-normalize
+ * @see https://github.com/ergebnis/composer-normalize
  */
 
-namespace Localheinz\Composer\Normalize\Test\Util;
+namespace Ergebnis\Composer\Normalize\Test\Util;
 
 final class State
 {


### PR DESCRIPTION
This PR

* [x] renames the namespace `Localheinz\Composer\Normalize` to `Ergebnis\Composer\Normalize` after the move to @ergebnis