### PR TITLE
Fix: Mark classes as internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ For a full diff see [`1.3.1...master`][1.3.1...master]
   ```
 
   to delete backup files created in the previous step.
+* Marked `Ergebnis\Composer\Normalize\Command\NormalizeCommand` and `Ergebnis\Composer\Normalize\Command\SchemaUriResolver` as internal to allow modifications without the need for major releases ([#270]), by [@localheinz]
 
 ### Fixed
 
@@ -286,6 +287,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#261]: https://github.com/ergebnis/composer-normalize/pull/261
 [#262]: https://github.com/ergebnis/composer-normalize/pull/262
 [#267]: https://github.com/ergebnis/composer-normalize/pull/267
+[#270]: https://github.com/ergebnis/composer-normalize/pull/270
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -19,6 +19,9 @@ use Ergebnis\Json\Normalizer;
 use Localheinz\Diff;
 use Symfony\Component\Console;
 
+/**
+ * @internal
+ */
 final class NormalizeCommand extends Command\BaseCommand
 {
     /**

--- a/src/Command/SchemaUriResolver.php
+++ b/src/Command/SchemaUriResolver.php
@@ -15,6 +15,9 @@ namespace Ergebnis\Composer\Normalize\Command;
 
 use Composer\Json;
 
+/**
+ * @internal
+ */
 final class SchemaUriResolver
 {
     public static function resolve(): string


### PR DESCRIPTION
This PR

* [x] marks classes as internal to allow modifications without the need for a major release

💁‍♂ Besides, nobody would want to use these classes directly anyway.