### PR TITLE
Fix: Run schema workflow every hour

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -4,7 +4,7 @@ name: "Schema"
 
 on:
   schedule:
-    - cron: "0 12 * * *"
+    - cron: "0 * * * *"
 
 jobs:
   schema:


### PR DESCRIPTION
This PR

* [x] runs the schema workflow every hour

Follows #288.

💁‍♂ Perhaps we'll reduce it after seeing it at least run successfully once.