### PR TITLE
Fix: Check for schema updates only once a day

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -4,7 +4,7 @@ name: "Schema"
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 12 * * *"
 
 jobs:
   schema:


### PR DESCRIPTION
This PR

* [x] increases the interval used for checking schema updates from 1 hour to 24 hours