### PR TITLE
Enhancement: Show version of ergebnis/composer-normalize

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -285,6 +285,9 @@ jobs:
       - name: "Require composer/composer"
         run: "composer require composer/composer:1.9.1 --no-interaction --no-progress --no-suggest"
 
+      - name: "Remove git placeholder configuration with jq"
+        run: "echo $(cat box.json | jq 'del(.git)') > box.json"
+
       - name: "Validate configuration for humbug/box"
         run: "phar/box.phar validate box.json"
 

--- a/box.json
+++ b/box.json
@@ -8,6 +8,7 @@
   "files": [
     "resource/schema.json"
   ],
+  "git": "git",
   "main": "phar/composer-normalize.php",
   "output": ".build/phar/composer-normalize.phar"
 }

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -17,6 +17,7 @@
     "void",
     "Composer\\Command\\BaseCommand",
     "Composer\\Composer",
+    "Composer\\Console\\Application",
     "Composer\\Factory",
     "Composer\\IO\\IOInterface",
     "Composer\\Json\\JsonFile",

--- a/phar/composer-normalize.php
+++ b/phar/composer-normalize.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/composer-normalize
  */
 
-use Composer\Console\Application;
-use Ergebnis\Composer\Json\Normalizer\ComposerJsonNormalizer;
+use Composer\Factory;
+use Ergebnis\Composer\Json;
 use Ergebnis\Composer\Normalize;
 use Ergebnis\Json\Normalizer;
 use Ergebnis\Json\Printer;
@@ -21,8 +21,8 @@ use Localheinz\Diff;
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $command = new Normalize\Command\NormalizeCommand(
-    new Composer\Factory(),
-    new ComposerJsonNormalizer(__DIR__ . '/../resource/schema.json'),
+    new Factory(),
+    new Json\Normalizer\ComposerJsonNormalizer(__DIR__ . '/../resource/schema.json'),
     new Normalizer\Format\Formatter(new Printer\Printer()),
     new Diff\Differ(new Diff\Output\StrictUnifiedDiffOutputBuilder([
         'fromFile' => 'original',
@@ -30,7 +30,7 @@ $command = new Normalize\Command\NormalizeCommand(
     ]))
 );
 
-$application = new Application();
+$application = new Normalize\Application();
 
 $application->add($command);
 $application->setDefaultCommand($command->getName());

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ parameters:
 	ergebnis:
 		classesAllowedToBeExtended:
 			- Composer\Command\BaseCommand
+			- Composer\Console\Application
 			- LogicException
 	inferPrivatePropertyTypeFromConstructor: true
 	level: max

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/composer-normalize
+ */
+
+namespace Ergebnis\Composer\Normalize;
+
+use Composer\Console;
+
+/**
+ * @internal
+ */
+final class Application extends Console\Application
+{
+    public function getLongVersion(): string
+    {
+        return \sprintf(
+            '%s <info>%s</info> with ergebnis/composer-normalize <info>@git@</info>',
+            $this->getName(),
+            $this->getVersion()
+        );
+    }
+}

--- a/test/Unit/ApplicationTest.php
+++ b/test/Unit/ApplicationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/composer-normalize
+ */
+
+namespace Ergebnis\Composer\Normalize\Test\Unit;
+
+use Ergebnis\Composer\Normalize\Application;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\Composer\Normalize\Application
+ */
+final class ApplicationTest extends Framework\TestCase
+{
+    public function testGetLongVersionReturnsVersion(): void
+    {
+        $composerApplication = new \Composer\Console\Application();
+        $application = new Application();
+
+        $expected = \sprintf(
+            '%s <info>%s</info> with ergebnis/composer-normalize <info>@git@</info>',
+            $composerApplication->getName(),
+            $composerApplication->getVersion()
+        );
+
+        self::assertSame($expected, $application->getLongVersion());
+    }
+}


### PR DESCRIPTION
This PR

* [x] shows the version of `ergebnis/composer-normalize`

### Before

Running

```
$ make phar && .build/phar/composer-normalize.phar --version
```

yields

```
Composer 1.9.1 2019-11-01 17:20:17
```

### After

Running

```
$ make phar && .build/phar/composer-normalize.phar --version
```

yields

```
Composer 1.9.1 with ergebnis/composer-normalize 2.1.1@9cfafd3
```