### PR TITLE
Enhancement: Remove dependency on ergebnis/composer-json-normalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-For a full diff see [`2.2.0...master`][2.2.0...master].
+For a full diff see [`2.2.1...master`][2.2.1...master].
+
+## [`2.2.1`][2.2.1]
+
+For a full diff see [`2.2.0...2.2.1`][2.2.0...2.2.1].
+
+### Changed
+
+* Removed dependency on `ergebnis/composer-json-normalizer` ([#316]), by [@localheinz]
 
 ## [`2.2.0`][2.2.0]
 
@@ -293,6 +301,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [2.1.1]: https://github.com/ergebnis/composer-normalize/releases/tag/2.1.1
 [2.1.2]: https://github.com/ergebnis/composer-normalize/releases/tag/2.1.2
 [2.2.0]: https://github.com/ergebnis/composer-normalize/releases/tag/2.2.0
+[2.2.1]: https://github.com/ergebnis/composer-normalize/releases/tag/2.2.1
 
 [81bc3a8...0.1.0]: https://github.com/ergebnis/composer-normalize/compare/81bc3a8...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/composer-normalize/compare/0.1.0...0.2.0
@@ -319,7 +328,8 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [2.1.0...2.1.1]: https://github.com/ergebnis/composer-normalize/compare/2.1.0...2.1.1
 [2.1.1...2.1.2]: https://github.com/ergebnis/composer-normalize/compare/2.1.1...2.1.2
 [2.1.2...2.2.0]: https://github.com/ergebnis/composer-normalize/compare/2.1.2...2.2.0
-[2.2.0...master]: https://github.com/ergebnis/composer-normalize/compare/2.2.0...master
+[2.2.0...2.2.1]: https://github.com/ergebnis/composer-normalize/compare/2.2.0...2.2.1
+[2.2.1...master]: https://github.com/ergebnis/composer-normalize/compare/2.2.1...master
 
 [#1]: https://github.com/ergebnis/composer-normalize/pull/1
 [#2]: https://github.com/ergebnis/composer-normalize/pull/2
@@ -360,6 +370,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#297]: https://github.com/ergebnis/composer-normalize/pull/297
 [#301]: https://github.com/ergebnis/composer-normalize/pull/301
 [#303]: https://github.com/ergebnis/composer-normalize/pull/303
+[#316]: https://github.com/ergebnis/composer-normalize/pull/316
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
   "require": {
     "php": "^7.1",
     "composer-plugin-api": "^1.1.0",
-    "ergebnis/composer-json-normalizer": "^2.0.1",
-    "ergebnis/json-normalizer": "~0.10.1",
+    "ergebnis/json-normalizer": "~0.11.0",
     "ergebnis/json-printer": "^3.0.2",
     "localheinz/diff": "^1.0.1"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,77 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5333f1324880c433c60d13599cbab2d9",
+    "content-hash": "dbd68a7c5898450f0f3427425c3a63bc",
     "packages": [
         {
-            "name": "ergebnis/composer-json-normalizer",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ergebnis/composer-json-normalizer.git",
-                "reference": "0279214509baf22905c99fe5528e1b74533e6a42"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/composer-json-normalizer/zipball/0279214509baf22905c99fe5528e1b74533e6a42",
-                "reference": "0279214509baf22905c99fe5528e1b74533e6a42",
-                "shasum": ""
-            },
-            "require": {
-                "ergebnis/json-normalizer": "~0.10.1",
-                "ext-json": "*",
-                "justinrainbow/json-schema": "^4.0.0 || ^5.0.0",
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "ergebnis/php-cs-fixer-config": "~1.1.2",
-                "ergebnis/phpstan-rules": "~0.14.2",
-                "ergebnis/test-util": "~0.9.1",
-                "infection/infection": "~0.13.6",
-                "jangregor/phpstan-prophecy": "~0.5.0",
-                "phpstan/extension-installer": "^1.0.3",
-                "phpstan/phpstan": "~0.11.19",
-                "phpstan/phpstan-deprecation-rules": "~0.11.2",
-                "phpstan/phpstan-strict-rules": "~0.11.1",
-                "phpunit/phpunit": "^7.5.18"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Ergebnis\\Composer\\Json\\Normalizer\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "am@localheinz.com"
-                }
-            ],
-            "description": "Provides normalizers for normalizing composer.json.",
-            "homepage": "https://github.com/ergebnis/composer-json-normalizer",
-            "keywords": [
-                "composer",
-                "json",
-                "normalizer"
-            ],
-            "time": "2019-12-19T17:12:18+00:00"
-        },
-        {
             "name": "ergebnis/json-normalizer",
-            "version": "0.10.1",
+            "version": "0.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ergebnis/json-normalizer.git",
-                "reference": "0948169c680527940928d166b447a044b9c9e71e"
+                "reference": "6a41d9a53f640bff8ef5516efd3aadc6f1ad1f37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/json-normalizer/zipball/0948169c680527940928d166b447a044b9c9e71e",
-                "reference": "0948169c680527940928d166b447a044b9c9e71e",
+                "url": "https://api.github.com/repos/ergebnis/json-normalizer/zipball/6a41d9a53f640bff8ef5516efd3aadc6f1ad1f37",
+                "reference": "6a41d9a53f640bff8ef5516efd3aadc6f1ad1f37",
                 "shasum": ""
             },
             "require": {
@@ -84,17 +27,20 @@
                 "php": "^7.1"
             },
             "require-dev": {
-                "ergebnis/php-cs-fixer-config": "~1.1.2",
+                "ergebnis/php-cs-fixer-config": "^1.1.3",
                 "ergebnis/phpstan-rules": "~0.14.2",
                 "ergebnis/test-util": "~0.9.1",
                 "infection/infection": "~0.13.6",
-                "jangregor/phpstan-prophecy": "~0.4.2",
+                "jangregor/phpstan-prophecy": "~0.6.0",
                 "phpbench/phpbench": "~0.16.10",
                 "phpstan/extension-installer": "^1.0.3",
-                "phpstan/phpstan": "~0.11.19",
-                "phpstan/phpstan-deprecation-rules": "~0.11.2",
-                "phpstan/phpstan-strict-rules": "~0.11.1",
-                "phpunit/phpunit": "^7.5.18"
+                "phpstan/phpstan": "~0.12.4",
+                "phpstan/phpstan-deprecation-rules": "~0.12.1",
+                "phpstan/phpstan-phpunit": "~0.12.5",
+                "phpstan/phpstan-strict-rules": "~0.12.1",
+                "phpunit/phpunit": "^7.5.20",
+                "psalm/plugin-phpunit": "~0.8.0",
+                "vimeo/psalm": "^3.8.2"
             },
             "type": "library",
             "autoload": {
@@ -112,13 +58,13 @@
                     "email": "am@localheinz.com"
                 }
             ],
-            "description": "Provides normalizers for normalizing JSON documents.",
+            "description": "Provides generic and vendor-specific normalizers for normalizing JSON documents.",
             "homepage": "https://github.com/ergebnis/json-normalizer",
             "keywords": [
                 "json",
                 "normalizer"
             ],
-            "time": "2019-12-19T16:36:22+00:00"
+            "time": "2020-01-09T13:43:00+00:00"
         },
         {
             "name": "ergebnis/json-printer",

--- a/phar/composer-normalize.php
+++ b/phar/composer-normalize.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
  */
 
 use Composer\Factory;
-use Ergebnis\Composer\Json;
 use Ergebnis\Composer\Normalize;
 use Ergebnis\Json\Normalizer;
 use Ergebnis\Json\Printer;
@@ -23,7 +22,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 $command = new Normalize\Command\NormalizeCommand(
     new Factory(),
-    new Json\Normalizer\ComposerJsonNormalizer(__DIR__ . '/../resource/schema.json'),
+    new Normalizer\Vendor\Composer\ComposerJsonNormalizer(__DIR__ . '/../resource/schema.json'),
     new Normalizer\Format\Formatter(new Printer\Printer()),
     new Diff\Differ(new Diff\Output\StrictUnifiedDiffOutputBuilder([
         'fromFile' => 'original',

--- a/src/NormalizePlugin.php
+++ b/src/NormalizePlugin.php
@@ -17,7 +17,6 @@ use Composer\Composer;
 use Composer\Factory;
 use Composer\IO;
 use Composer\Plugin;
-use Ergebnis\Composer\Json\Normalizer\ComposerJsonNormalizer;
 use Ergebnis\Json\Normalizer;
 use Ergebnis\Json\Printer;
 use Localheinz\Diff;
@@ -40,7 +39,7 @@ final class NormalizePlugin implements Plugin\Capability\CommandProvider, Plugin
         return [
             new Command\NormalizeCommand(
                 new Factory(),
-                new ComposerJsonNormalizer(\sprintf(
+                new Normalizer\Vendor\Composer\ComposerJsonNormalizer(\sprintf(
                     'file://%s',
                     __DIR__ . '/../resource/schema.json'
                 )),


### PR DESCRIPTION
This PR

* [x] removes `ergebnis/composer-json-normalizer` and updates `ergebnis/json-normalizer`


💁‍♂ For reference, see https://github.com/ergebnis/json-normalizer/compare/0.10.1...0.11.0.