### PR TITLE
Fix: Allow @localheinz to push to master

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -40,6 +40,7 @@ branches:
         teams: []
         users:
           - "ergebnis-bot"
+          - "localheinz"
 
 # https://developer.github.com/v3/issues/labels/#create-a-label
 # https://developer.github.com/v3/issues/labels/#update-a-label


### PR DESCRIPTION
This PR

* [x] allows @localheinz to push to `master`

Follows #322.

💁‍♂ For reference, see https://github.community/t5/GitHub-Actions/Who-will-be-the-GitHub-actor-when-a-workflow-runs-on-a-schedule/m-p/43362#M5355.