### PR TITLE
Fix: Remove @localheinz from list of user allowed to push to master

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -40,7 +40,6 @@ branches:
         teams: []
         users:
           - "ergebnis-bot"
-          - "localheinz"
 
 # https://developer.github.com/v3/issues/labels/#create-a-label
 # https://developer.github.com/v3/issues/labels/#update-a-label


### PR DESCRIPTION
This PR

* [x] removes @localheinz from the list of users allowed to push to `master`

Follows #325.