### PR TITLE
Fix: Use different email address for @ergebnis-bot

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "Open pull request updating schema"
         uses: "gr2m/create-or-update-pull-request-action@v1.2.9"
         with:
-          author: "<am+ergebnis+bot@localheinz.com>"
+          author: "<bot@ergebn.is>"
           branch: "feature/schema"
           body: |
             This PR


### PR DESCRIPTION
This PR

* [x] uses a different email address for @ergebnis-bot 