### PR TITLE
Fix validate sub-command after normalizer failure

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -24,6 +24,7 @@
     "Composer\\Plugin\\Capability\\CommandProvider",
     "Composer\\Plugin\\Capable",
     "Composer\\Plugin\\PluginInterface",
+    "Symfony\\Component\\Console\\Application",
     "Symfony\\Component\\Console\\Input\\ArrayInput",
     "Symfony\\Component\\Console\\Input\\InputArgument",
     "Symfony\\Component\\Console\\Input\\InputInterface",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5,3 +5,8 @@ parameters:
 			count: 1
 			path: src/Command/NormalizeCommand.php
 
+		-
+			message: "#^Call to function method_exists\\(\\) with Symfony\\\\Component\\\\Console\\\\Application and 'isAutoExitEnabled' will always evaluate to true\\.$#"
+			count: 1
+			path: src/Command/NormalizeCommand.php
+

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -165,10 +165,12 @@ final class NormalizeCommand extends Command\BaseCommand
                 $exception->getMessage()
             ));
 
-            return $this->validateComposerFile(
+            $this->validateComposerFile(
                 $output,
                 $composerFile
             );
+
+            return 1;
         } catch (\RuntimeException $exception) {
             $io->writeError(\sprintf(
                 '<error>%s</error>',

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -369,7 +369,7 @@ final class NormalizeCommand extends Command\BaseCommand
                 'file' => $composerFile,
                 '--no-check-all' => true,
                 '--no-check-lock' => true,
-                '--no-check-publish' => true,
+                //'--no-check-publish' => true,
                 //'--strict' => true,
             ]),
             $output

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -370,7 +370,7 @@ final class NormalizeCommand extends Command\BaseCommand
                 '--no-check-all' => true,
                 '--no-check-lock' => true,
                 '--no-check-publish' => true,
-                '--strict' => true,
+                //'--strict' => true,
             ]),
             $output
         );

--- a/test/Integration/Command/NormalizeCommandTest.php
+++ b/test/Integration/Command/NormalizeCommandTest.php
@@ -249,6 +249,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         self::assertRegExp('/Original JSON is not valid according to schema ".*"/', $display);
         self::assertContains('See https://getcomposer.org/doc/04-schema.md for details on the schema', $display);
         self::assertContains('No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.', $display);
+        self::assertContains('name : The property name is required', $display);
         self::assertEquals($initialState, $scenario->currentState());
     }
 


### PR DESCRIPTION
This PR

* [x] fixes that the sub-commands were exiting instead of returning the status code
* [x] removes the `--strict` option from the post-failure call to `validate`, to avoid https://github.com/composer/composer/issues/8602 (and its linked issues)
* [x] removes the `--no-check-publish` option from the post-failure call to `validate`, because "publish errors" *are* (strict) schema violations
* [x] makes sure the `normalize` command returns `1` rather than `0` or `2` when it failed because of schema errors

Related to #349 (part of; doesn't address the question of relaxing validation in the normalizer).
Related to #25.
