### PR TITLE
Fix: Update composer/composer as used for composer-normalize.phar

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -8,7 +8,7 @@ on:
       - "**"
 
 env:
-  COMPOSER_VERSION: "1.9.1"
+  COMPOSER_VERSION: "1.9.3"
   REQUIRED_PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,7 +9,7 @@ on:
       - "master"
 
 env:
-  COMPOSER_VERSION: "1.9.1"
+  COMPOSER_VERSION: "1.9.3"
   REQUIRED_PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMPOSER_VERSION:=1.9.1
+COMPOSER_VERSION:=1.9.3
 
 .PHONY: it
 it: coding-standards dependency-analysis static-code-analysis tests ## Runs the coding-standards, dependency-analysis, static-code-analysis, and tests targets


### PR DESCRIPTION
This PR

* [x] updates `composer/composer` as used for `composer-normalize.phar`

Follows #365.

💁‍♂ For reference, see https://github.com/composer/composer/compare/1.9.1...1.9.3.