### PR TITLE
Fix: Use same version of composer/composer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMPOSER_VERSION:=1.9.3
+COMPOSER_VERSION:=1.10.0
 
 .PHONY: it
 it: coding-standards dependency-analysis static-code-analysis tests ## Runs the coding-standards, dependency-analysis, static-code-analysis, and tests targets


### PR DESCRIPTION
This PR

* [x] uses the same version of `composer/composer` in `Makefile` as in the previously updated workflow

Follows #375.