### PR TITLE
Enhancement: Show validation error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.3.2...master`][2.3.2...master].
 
+### Changed
+
+* Started showing validation error messages as obtained from validation instead of relying on on executing composer validate ([#406]), by [@localheinz]
+
 ## [`2.3.2`][2.3.2]
 
 For a full diff see [`2.3.1...2.3.2`][2.3.1...2.3.2].
@@ -436,6 +440,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#374]: https://github.com/ergebnis/composer-normalize/pull/374
 [#379]: https://github.com/ergebnis/composer-normalize/pull/379
 [#380]: https://github.com/ergebnis/composer-normalize/pull/380
+[#406]: https://github.com/ergebnis/composer-normalize/pull/406
 
 [@ergebnis]: https://github.com/ergebnis
 [@ergebnis-bot]: https://github.com/ergebnis-bot

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.10.1@eeed5ecccc10131397f0eb7ee6da810c0be3a7fc">
+<files psalm-version="3.11.2@d470903722cfcbc1cd04744c5491d3e6d13ec3d9">
   <file src="src/Application.php">
     <PropertyNotSetInConstructor occurrences="1">
       <code>Application</code>
@@ -12,8 +12,7 @@
       <code>$formatter</code>
       <code>$differ</code>
     </MissingPropertyType>
-    <MixedArgument occurrences="11">
-      <code>$composerFile</code>
+    <MixedArgument occurrences="10">
       <code>$composerFile</code>
       <code>$composerFile</code>
       <code>$composerFile</code>
@@ -45,8 +44,7 @@
       <code>isLocked</code>
       <code>diff</code>
     </MixedMethodCall>
-    <PossiblyInvalidArgument occurrences="9">
-      <code>$composerFile</code>
+    <PossiblyInvalidArgument occurrences="8">
       <code>$composerFile</code>
       <code>$composerFile</code>
       <code>$composerFile</code>

--- a/test/Integration/Command/NormalizeCommandTest.php
+++ b/test/Integration/Command/NormalizeCommandTest.php
@@ -252,8 +252,8 @@ final class NormalizeCommandTest extends Framework\TestCase
         );
 
         self::assertContains($message, $display);
+        self::assertContains('The property name is required', $display);
         self::assertContains('See https://getcomposer.org/doc/04-schema.md for details on the schema', $display);
-        self::assertContains('No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.', $display);
         self::assertEquals($initialState, $scenario->currentState());
     }
 


### PR DESCRIPTION
This PR

* [x] shows validation error messages as obtained from validation instead of relying on on executing `composer validate`

Slightly related to #349.
Slightly related to #352.