### PR TITLE
Fix: Avoid display of override message when updating lock file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For a full diff see [`2.5.0...master`][2.5.0...master].
 
 ### Fixed
 
+* Started updating lock files with a new `Composer\Console\Application` instead of reusing the current instance ([#420]), by [@localheinz]
 * Stopped using the deprecated `--no-suggest` option when updating the lock file ([#422]), by [@localheinz]
 
 ## [`2.5.0`][2.5.0]
@@ -464,6 +465,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#406]: https://github.com/ergebnis/composer-normalize/pull/406
 [#412]: https://github.com/ergebnis/composer-normalize/pull/412
 [#416]: https://github.com/ergebnis/composer-normalize/pull/416
+[#420]: https://github.com/ergebnis/composer-normalize/pull/420
 [#422]: https://github.com/ergebnis/composer-normalize/pull/422
 
 [@ergebnis]: https://github.com/ergebnis

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\Composer\Normalize\Command;
 
 use Composer\Command;
+use Composer\Console\Application;
 use Composer\Factory;
 use Composer\IO;
 use Ergebnis\Composer\Normalize\Exception;
@@ -235,10 +236,12 @@ final class NormalizeCommand extends Command\BaseCommand
 
         $io->write('<info>Updating lock file.</info>');
 
-        $this->resetComposer();
+        $application = new Application();
+
+        $application->setAutoExit(false);
 
         return self::updateLockerInWorkingDirectory(
-            $this->getApplication(),
+            $application,
             $output,
             \dirname($composerFile)
         );

--- a/test/Fixture/json/valid/lock/present/lock/fresh-before/json/not-yet-normalized/lock/not-fresh-after/composer.json
+++ b/test/Fixture/json/valid/lock/present/lock/fresh-before/json/not-yet-normalized/lock/not-fresh-after/composer.json
@@ -10,5 +10,8 @@
     "ext-json": "*",
     "php": "^7.1"
   },
-  "_comment": "This composer.json is valid according to a lax validation, , a composer.lock is present and fresh before invoking the command, composer.json is not yet normalized, and composer.lock is not fresh after invoking the command."
+  "scripts": {
+    "hello": "echo 'Hello!'"
+  },
+  "_comment": "This composer.json is valid according to a lax validation, a composer.lock is present and fresh before invoking the command, composer.json is not yet normalized, and composer.lock is not fresh after invoking the command."
 }

--- a/test/Integration/Command/NormalizeCommandTest.php
+++ b/test/Integration/Command/NormalizeCommandTest.php
@@ -730,12 +730,16 @@ final class NormalizeCommandTest extends Framework\TestCase
 
         self::assertExitCodeSame(0, $exitCode);
 
+        $display = $output->fetch();
+
+        self::assertStringNotContainsString('A script named hello would override a Composer command and has been skipped', $display);
+
         $expected = \sprintf(
             'Successfully normalized %s.',
             $scenario->composerJsonFileReference()
         );
 
-        self::assertStringContainsString($expected, $output->fetch());
+        self::assertStringContainsString($expected, $display);
 
         $currentState = $scenario->currentState();
 


### PR DESCRIPTION
This PR

* [x] asserts that override messages are not displayed when updating lock file
* [x] avoids display of override messages when updating lock file

Fixes #418.