### PR TITLE
Fix: Stop using deprecated --no-suggest option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.5.0...master`][2.5.0...master].
 
+### Fixed
+
+* Stopped using the deprecated `--no-suggest` option when updating the lock file ([#422]), by [@localheinz]
+
 ## [`2.5.0`][2.5.0]
 
 For a full diff see [`2.4.0...2.5.0`][2.4.0...2.5.0].
@@ -460,6 +464,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#406]: https://github.com/ergebnis/composer-normalize/pull/406
 [#412]: https://github.com/ergebnis/composer-normalize/pull/412
 [#416]: https://github.com/ergebnis/composer-normalize/pull/416
+[#422]: https://github.com/ergebnis/composer-normalize/pull/422
 
 [@ergebnis]: https://github.com/ergebnis
 [@ergebnis-bot]: https://github.com/ergebnis-bot

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -371,7 +371,6 @@ final class NormalizeCommand extends Command\BaseCommand
                 '--no-autoloader' => true,
                 '--no-plugins' => true,
                 '--no-scripts' => true,
-                '--no-suggest' => true,
                 '--working-dir' => $workingDirectory,
             ]),
             $output


### PR DESCRIPTION
This PR

* [x] stops using the deprecated `--no-suggest` option when updating the lock file