### PR TITLE
Fix: Use main as default branch name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,7 +1,7 @@
 # https://github.com/probot/settings
 
 branches:
-  - name: "master"
+  - name: "main"
 
     # https://developer.github.com/v3/repos/branches/#remove-branch-protection
     # https://developer.github.com/v3/repos/branches/#update-branch-protection
@@ -97,7 +97,7 @@ repository:
   allow_rebase_merge: false
   allow_squash_merge: false
   archived: false
-  default_branch: "master"
+  default_branch: "main"
   delete_branch_on_merge: true
   description: ":musical_note: Provides a composer plugin for normalizing composer.json."
   has_downloads: true

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
   pull_request: null
   push:
     branches:
-      - "master"
+      - "main"
 
 env:
   COMPOSER_VERSION: "1.10.5"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.5.1...master`][2.5.1...master].
+For a full diff see [`2.5.1...main`][2.5.1...main].
 
 ## [`2.5.1`][2.5.1]
 
@@ -418,10 +418,10 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [2.2.4...2.3.0]: https://github.com/ergebnis/composer-normalize/compare/2.2.4...2.3.0
 [2.3.0...2.3.1]: https://github.com/ergebnis/composer-normalize/compare/2.3.0...2.3.1
 [2.3.1...2.3.2]: https://github.com/ergebnis/composer-normalize/compare/2.3.1...2.3.2
-[2.3.2...2.4.0]: https://github.com/ergebnis/composer-normalize/compare/2.4.0...master
+[2.3.2...2.4.0]: https://github.com/ergebnis/composer-normalize/compare/2.4.0...main
 [2.4.0...2.5.0]: https://github.com/ergebnis/composer-normalize/compare/2.4.0...2.5.0
 [2.5.0...2.5.1]: https://github.com/ergebnis/composer-normalize/compare/2.5.0...2.5.1
-[2.5.1...master]: https://github.com/ergebnis/composer-normalize/compare/2.5.1...master
+[2.5.1...main]: https://github.com/ergebnis/composer-normalize/compare/2.5.1...main
 
 [#1]: https://github.com/ergebnis/composer-normalize/pull/1
 [#2]: https://github.com/ergebnis/composer-normalize/pull/2

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # composer-normalize
 
-[![Integrate](https://github.com/ergebnis/composer-normalize/workflows/Integrate/badge.svg?branch=master)](https://github.com/ergebnis/composer-normalize/actions)
-[![Prune](https://github.com/ergebnis/composer-normalize/workflows/Prune/badge.svg?branch=master)](https://github.com/ergebnis/composer-normalize/actions)
-[![Release](https://github.com/ergebnis/composer-normalize/workflows/Release/badge.svg?branch=master)](https://github.com/ergebnis/composer-normalize/actions)
-[![Renew](https://github.com/ergebnis/composer-normalize/workflows/Renew/badge.svg?branch=master)](https://github.com/ergebnis/composer-normalize/actions)
-[![Update](https://github.com/ergebnis/composer-normalize/workflows/Update/badge.svg?branch=master)](https://github.com/ergebnis/composer-normalize/actions)
+[![Integrate](https://github.com/ergebnis/composer-normalize/workflows/Integrate/badge.svg?branch=main)](https://github.com/ergebnis/composer-normalize/actions)
+[![Prune](https://github.com/ergebnis/composer-normalize/workflows/Prune/badge.svg?branch=main)](https://github.com/ergebnis/composer-normalize/actions)
+[![Release](https://github.com/ergebnis/composer-normalize/workflows/Release/badge.svg?branch=main)](https://github.com/ergebnis/composer-normalize/actions)
+[![Renew](https://github.com/ergebnis/composer-normalize/workflows/Renew/badge.svg?branch=main)](https://github.com/ergebnis/composer-normalize/actions)
+[![Update](https://github.com/ergebnis/composer-normalize/workflows/Update/badge.svg?branch=main)](https://github.com/ergebnis/composer-normalize/actions)
 
-[![Code Coverage](https://codecov.io/gh/ergebnis/composer-normalize/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/composer-normalize)
+[![Code Coverage](https://codecov.io/gh/ergebnis/composer-normalize/branch/main/graph/badge.svg)](https://codecov.io/gh/ergebnis/composer-normalize)
 [![Type Coverage](https://shepherd.dev/github/ergebnis/composer-normalize/coverage.svg)](https://shepherd.dev/github/ergebnis/composer-normalize)
 
 [![Latest Stable Version](https://poser.pugx.org/ergebnis/composer-normalize/v/stable)](https://packagist.org/packages/ergebnis/composer-normalize)
@@ -532,7 +532,7 @@ Please have a look at [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).
 
 ## Code of Conduct
 
-Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/master/CODE_OF_CONDUCT.md).
+Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
This PR

* [x] uses `main` as default branch name

✊🏿 Black lives matter.