### PR TITLE
Fix: Use appropriate data provider

### DIFF
--- a/test/Integration/Command/NormalizeCommandTest.php
+++ b/test/Integration/Command/NormalizeCommandTest.php
@@ -306,7 +306,7 @@ final class NormalizeCommandTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerCommandInvocationAndInvalidIndentSize
+     * @dataProvider providerCommandInvocation
      *
      * @param CommandInvocation $commandInvocation
      */


### PR DESCRIPTION
This PR

* [x] uses an appropriate data provider