### PR TITLE
Fix: Continue to run jobs in test matrix when a job failed

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -251,6 +251,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - "7.1"


### PR DESCRIPTION
This PR

* [x] continues to run jobs in the `test` matrix when a job failed

💁‍♂️ For reference, see https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast.