### PR TITLE
Fix: Use assertStringContainsString()

### DIFF
--- a/test/Integration/Command/NormalizeCommandTest.php
+++ b/test/Integration/Command/NormalizeCommandTest.php
@@ -247,7 +247,7 @@ final class NormalizeCommandTest extends Framework\TestCase
         );
 
         self::assertExitCodeSame(1, $exitCode);
-        self::assertContains('does not match the expected JSON schema', $output->fetch());
+        self::assertStringContainsString('does not match the expected JSON schema', $output->fetch());
         self::assertEquals($initialState, $scenario->currentState());
     }
 


### PR DESCRIPTION
This PR

* [x] uses `assertStringContainsString()`