### PR TITLE
Fix: Remove configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,18 +24,6 @@ updates:
 
   - commit-message:
       include: "scope"
-      prefix: "composer"
-    directory: "/tools"
-    labels:
-      - "dependency"
-    open-pull-requests-limit: 10
-    package-ecosystem: "composer"
-    schedule:
-      interval: "daily"
-    versioning-strategy: "increase"
-
-  - commit-message:
-      include: "scope"
       prefix: "github-actions"
     directory: "/"
     labels:


### PR DESCRIPTION
This PR

* [x] removes an unnecessary configuration for Dependabot

Follows #579.