### PR TITLE
Fix: Remove ergebnis/php-cs-fixer-config to allow building PHAR

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -368,6 +368,9 @@ jobs:
         with:
           dependencies: "${{ matrix.dependencies }}"
 
+      - name: "Remove ergebnis/php-cs-fixer-config to avoid dependency conflicts"
+        run: "composer remove ergebnis/php-cs-fixer-config --dev --no-interaction --no-progress"
+
       - name: "Remove composer/composer"
         run: "composer remove composer/composer --no-interaction --no-progress"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,9 @@ jobs:
         with:
           dependencies: "${{ matrix.dependencies }}"
 
+      - name: "Remove ergebnis/php-cs-fixer-config to avoid dependency conflicts"
+        run: "composer remove ergebnis/php-cs-fixer-config --dev --no-interaction --no-progress"
+
       - name: "Remove composer/composer"
         run: "composer remove composer/composer --no-interaction --no-progress"
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ help: ## Displays this list of targets with descriptions
 .PHONY: phar
 phar: vendor ## Builds a phar with humbug/box
 	phar/box.phar validate box.json
+	composer remove ergebnis/php-cs-fixer-config --dev --no-interaction --no-progress
 	composer require composer/composer:${COMPOSER_VERSION}  --no-interaction --no-progress --update-with-dependencies
 	phar/box.phar compile --config=box.json
 	git checkout HEAD -- composer.json composer.lock


### PR DESCRIPTION
This PR

* [x] removes `ergebnis/php-cs-fixer-config` when building PHAR to allow installation of `composer/composer`

Replaces #588.