### PR TITLE
Fix: Remove deprecated --no-suggest option

### DIFF
--- a/.github/actions/composer/composer/install/run.sh
+++ b/.github/actions/composer/composer/install/run.sh
@@ -3,19 +3,19 @@
 dependencies="${COMPOSER_INSTALL_DEPENDENCIES}"
 
 if [[ ${dependencies} == "lowest" ]]; then
-  composer update --no-interaction --no-progress --no-suggest --prefer-lowest
+  composer update --no-interaction --no-progress --prefer-lowest
 
   exit $?
 fi
 
 if [[ ${dependencies} == "locked" ]]; then
-  composer install --no-interaction --no-progress --no-suggest
+  composer install --no-interaction --no-progress
 
   exit $?
 fi
 
 if [[ ${dependencies} == "highest" ]]; then
-  composer update --no-interaction --no-progress --no-suggest
+  composer update --no-interaction --no-progress
 
   exit $?
 fi

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -372,7 +372,7 @@ jobs:
         run: "composer remove composer/composer --no-interaction --no-progress"
 
       - name: "Require composer/composer"
-        run: "composer require composer/composer:${{ env.COMPOSER_VERSION }} --no-interaction --no-progress --no-suggest"
+        run: "composer require composer/composer:${{ env.COMPOSER_VERSION }} --no-interaction --no-progress"
 
       - name: "Remove git placeholder configuration with jq"
         run: "echo $(cat box.json | jq 'del(.git)') > box.json"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,7 @@ jobs:
         run: "composer remove composer/composer --no-interaction --no-progress"
 
       - name: "Require composer/composer"
-        run: "composer require composer/composer:${{ env.COMPOSER_VERSION }} --no-interaction --no-progress --no-suggest"
+        run: "composer require composer/composer:${{ env.COMPOSER_VERSION }} --no-interaction --no-progress"
 
       - name: "Validate configuration for humbug/box"
         run: "phar/box.phar validate box.json"

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ help: ## Displays this list of targets with descriptions
 .PHONY: phar
 phar: vendor ## Builds a phar with humbug/box
 	phar/box.phar validate box.json
-	composer require composer/composer:${COMPOSER_VERSION}  --no-interaction --no-progress --no-suggest --update-with-dependencies
+	composer require composer/composer:${COMPOSER_VERSION}  --no-interaction --no-progress --update-with-dependencies
 	phar/box.phar compile --config=box.json
 	git checkout HEAD -- composer.json composer.lock
 	phar/box.phar info .build/phar/composer-normalize.phar
@@ -61,4 +61,4 @@ tests: vendor ## Runs auto-review, unit, and integration tests with phpunit/phpu
 
 vendor: composer.json composer.lock
 	composer validate --strict
-	composer install --no-interaction --no-progress --no-suggest
+	composer install --no-interaction --no-progress


### PR DESCRIPTION
This PR

* [x] removes the deprecated `--no-suggest` option when running `composer`