### PR TITLE
Fix: Remove unused private method

### DIFF
--- a/test/Integration/Command/NormalizeCommandTest.php
+++ b/test/Integration/Command/NormalizeCommandTest.php
@@ -954,18 +954,6 @@ final class NormalizeCommandTest extends Framework\TestCase
         return self::createApplication($normalizeCommand);
     }
 
-    /**
-     * @return CommandInvocation[]
-     */
-    private static function commandInvocations(): array
-    {
-        return [
-            CommandInvocation::inCurrentWorkingDirectory(),
-            CommandInvocation::usingFileArgument(),
-            CommandInvocation::usingWorkingDirectoryOption(),
-        ];
-    }
-
     private static function assertComposerJsonFileExists(State $state): void
     {
         self::assertFileExists($state->composerJsonFile()->path());


### PR DESCRIPTION
This PR

* [x] removes an unused `private` method

Follows #602.