### PR TITLE
Fix: Use major.minor.patch version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,7 +106,7 @@ jobs:
 
       - name: "Upload composer-normalize.phar"
         if: "always()"
-        uses: "actions/upload-release-asset@v1"
+        uses: "actions/upload-release-asset@v1.0.2"
         env:
           GITHUB_TOKEN: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
         with:
@@ -117,7 +117,7 @@ jobs:
 
       - name: "Upload composer-normalize.phar.asc"
         if: "always()"
-        uses: "actions/upload-release-asset@v1"
+        uses: "actions/upload-release-asset@v1.0.2"
         env:
           GITHUB_TOKEN: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
         with:


### PR DESCRIPTION
This PR

* [x] uses `major.minor.patch` version for `actions/upload-release-asset`