### PR TITLE
Fix: Show version of plugin instead of version of application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.12.0...main`][2.12.0...main].
+For a full diff see [`2.12.1...main`][2.12.1...main].
+
+## [`2.12.1`][2.12.1]
+
+For a full diff see [`2.12.0...2.12.1`][2.12.0...2.12.1].
+
+### Fixed
+
+* Show version of plugin instead of version of `Composer\Console\Application` when running as development dependency ([#643]), by [@localheinz]
 
 ## [`2.12.0`][2.12.0]
 
@@ -510,6 +518,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [2.10.0]: https://github.com/ergebnis/composer-normalize/releases/tag/2.10.0
 [2.11.0]: https://github.com/ergebnis/composer-normalize/releases/tag/2.11.0
 [2.12.0]: https://github.com/ergebnis/composer-normalize/releases/tag/2.12.0
+[2.12.1]: https://github.com/ergebnis/composer-normalize/releases/tag/2.12.1
 
 [81bc3a8...0.1.0]: https://github.com/ergebnis/composer-normalize/compare/81bc3a8...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/composer-normalize/compare/0.1.0...0.2.0
@@ -558,7 +567,8 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [2.9.1...2.10.0]: https://github.com/ergebnis/composer-normalize/compare/2.9.1...2.10.0
 [2.10.0...2.11.0]: https://github.com/ergebnis/composer-normalize/compare/2.10.0...2.11.0
 [2.11.0...2.12.0]: https://github.com/ergebnis/composer-normalize/compare/2.11.0...2.12.0
-[2.12.0...main]: https://github.com/ergebnis/composer-normalize/compare/2.12.0...main
+[2.12.0...2.12.1]: https://github.com/ergebnis/composer-normalize/compare/2.12.0...2.12.1
+[2.12.1...main]: https://github.com/ergebnis/composer-normalize/compare/2.12.1...main
 
 [#1]: https://github.com/ergebnis/composer-normalize/pull/1
 [#2]: https://github.com/ergebnis/composer-normalize/pull/2
@@ -631,6 +641,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#634]: https://github.com/ergebnis/composer-normalize/pull/634
 [#640]: https://github.com/ergebnis/composer-normalize/pull/640
 [#641]: https://github.com/ergebnis/composer-normalize/pull/641
+[#643]: https://github.com/ergebnis/composer-normalize/pull/643
 
 [@core23]: https://github.com/core23
 [@dependabot]: https://github.com/dependabot

--- a/phar/composer-normalize.php
+++ b/phar/composer-normalize.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/composer-normalize
  */
 
+use Composer\Console\Application;
 use Composer\Factory;
 use Ergebnis\Composer\Normalize;
 use Ergebnis\Json\Normalizer;
@@ -30,7 +31,7 @@ $command = new Normalize\Command\NormalizeCommand(
     ]))
 );
 
-$application = new Normalize\Application();
+$application = new Application();
 
 $application->add($command);
 

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -18,6 +18,7 @@ use Composer\Console\Application;
 use Composer\Factory;
 use Composer\IO;
 use Ergebnis\Composer\Normalize\Exception;
+use Ergebnis\Composer\Normalize\Version;
 use Ergebnis\Json\Normalizer;
 use Localheinz\Diff;
 use Symfony\Component\Console;
@@ -107,7 +108,7 @@ final class NormalizeCommand extends Command\BaseCommand
         $io->write([
             \sprintf(
                 'Running %s.',
-                $this->getApplication()->getLongVersion()
+                Version::long()
             ),
             '',
         ]);

--- a/src/Version.php
+++ b/src/Version.php
@@ -13,53 +13,38 @@ declare(strict_types=1);
 
 namespace Ergebnis\Composer\Normalize;
 
-use Composer\Console;
-
 /**
  * @internal
  */
-final class Application extends Console\Application
+final class Version
 {
     /**
      * @see https://github.com/box-project/box/blob/master/doc/configuration.md#pretty-git-tag-placeholder-git
      *
      * @var string
      */
-    private $version = '@git@';
+    private static $version = '@git@';
 
-    public function getLongVersion(): string
+    public static function long(): string
     {
+        $name = 'ergebnis/composer-normalize';
         $attribution = 'by <info>Andreas Möller</info> and contributors';
 
-        $version = $this->getVersion();
+        $version = self::$version;
 
-        if ('' === $version) {
+        if ('@' . 'git@' === $version) {
             return \sprintf(
                 '<info>%s</info> %s',
-                $this->getName(),
+                $name,
                 $attribution
             );
         }
 
         return \sprintf(
             '<info>%s</info> %s %s',
-            $this->getName(),
+            $name,
             $version,
             $attribution
         );
-    }
-
-    public function getName(): string
-    {
-        return 'ergebnis/composer-normalize';
-    }
-
-    public function getVersion(): string
-    {
-        if ('@' . 'git@' === $this->version) {
-            return '';
-        }
-
-        return $this->version;
     }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/AdditionalKeys/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/AdditionalKeys/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/Missing/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/Missing/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotGreaterThanZero/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotGreaterThanZero/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotInteger/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotInteger/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/Missing/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/Missing/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotSpaceOrTab/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotSpaceOrTab/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotString/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotString/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Extra/Valid/WithOptions/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Extra/Valid/WithOptions/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Extra/Valid/WithoutOptions/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Extra/Valid/WithoutOptions/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Json/NotValid/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Json/NotValid/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/AlreadyNormalized/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/AlreadyNormalized/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/NotYetNormalized/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/NotYetNormalized/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/AlreadyNormalized/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/AlreadyNormalized/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/FreshAfter/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/FreshAfter/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/NotFreshAfter/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/NotFreshAfter/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/AlreadyNormalized/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/AlreadyNormalized/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/NotYetNormalized/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/NotYetNormalized/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithoutNoCheckLock/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithoutNoCheckLock/Test.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Normalizer/Throws/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Normalizer/Throws/Test.php
@@ -27,6 +27,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Integration/Command/NormalizeCommand/Options/NotValid/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Options/NotValid/Test.php
@@ -23,6 +23,8 @@ use Symfony\Component\Console;
  *
  * @covers \Ergebnis\Composer\Normalize\Command\NormalizeCommand
  * @covers \Ergebnis\Composer\Normalize\NormalizePlugin
+ *
+ * @uses \Ergebnis\Composer\Normalize\Version
  */
 final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 {

--- a/test/Unit/VersionTest.php
+++ b/test/Unit/VersionTest.php
@@ -13,22 +13,20 @@ declare(strict_types=1);
 
 namespace Ergebnis\Composer\Normalize\Test\Unit;
 
-use Ergebnis\Composer\Normalize\Application;
+use Ergebnis\Composer\Normalize\Version;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Ergebnis\Composer\Normalize\Application
+ * @covers \Ergebnis\Composer\Normalize\Version
  */
-final class ApplicationTest extends Framework\TestCase
+final class VersionTest extends Framework\TestCase
 {
-    public function testGetLongVersionReturnsVersion(): void
+    public function testLongReturnsVersion(): void
     {
-        $application = new Application();
-
         $expected = '<info>ergebnis/composer-normalize</info> by <info>Andreas Möller</info> and contributors';
 
-        self::assertSame($expected, $application->getLongVersion());
+        self::assertSame($expected, Version::long());
     }
 }


### PR DESCRIPTION
This PR

* [x] shows the version of the plugin instead of the version of the application when running as a development dependency

Follows #641.