### PR TITLE
Fix: Require composer/composer:2.0.13 for composer-normalize.phar

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -9,7 +9,7 @@ on: # yamllint disable-line rule:truthy
       - "main"
 
 env:
-  COMPOSER_VERSION: "2.0.8"
+  COMPOSER_VERSION: "2.0.13"
   PHP_EXTENSIONS: "mbstring"
   PHP_INI_VALUES: "memory_limit=-1, phar.readonly=0"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on: # yamllint disable-line rule:truthy
       - "**"
 
 env:
-  COMPOSER_VERSION: "2.0.8"
+  COMPOSER_VERSION: "2.0.13"
   PHP_EXTENSIONS: "mbstring"
   PHP_INI_VALUES: "memory_limit=-1, phar.readonly=0"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.13.3...main`][2.13.3...main].
+For a full diff see [`2.13.4...main`][2.13.4...main].
+
+## [`2.13.4`][2.13.4]
+
+For a full diff see [`2.13.3...2.13.4`][2.13.3...2.13.4].
+
+### Fixed
+
+* Required `composer/composer:2.0.13` for compiling `composer-normalize.phar` ([#743]), by [@localheinz]
 
 ## [`2.13.3`][2.13.3]
 
@@ -562,6 +570,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [2.13.1]: https://github.com/ergebnis/composer-normalize/releases/tag/2.13.1
 [2.13.2]: https://github.com/ergebnis/composer-normalize/releases/tag/2.13.2
 [2.13.3]: https://github.com/ergebnis/composer-normalize/releases/tag/2.13.3
+[2.13.4]: https://github.com/ergebnis/composer-normalize/releases/tag/2.13.4
 
 [81bc3a8...0.1.0]: https://github.com/ergebnis/composer-normalize/compare/81bc3a8...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/composer-normalize/compare/0.1.0...0.2.0
@@ -616,7 +625,8 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [2.13.0...2.13.1]: https://github.com/ergebnis/composer-normalize/compare/2.13.0...2.13.1
 [2.13.1...2.13.2]: https://github.com/ergebnis/composer-normalize/compare/2.13.1...2.13.2
 [2.13.2...2.13.3]: https://github.com/ergebnis/composer-normalize/compare/2.13.2...2.13.3
-[2.13.3...main]: https://github.com/ergebnis/composer-normalize/compare/2.13.3...main
+[2.13.3...2.13.4]: https://github.com/ergebnis/composer-normalize/compare/2.13.3...2.13.4
+[2.13.4...main]: https://github.com/ergebnis/composer-normalize/compare/2.13.4...main
 
 [#1]: https://github.com/ergebnis/composer-normalize/pull/1
 [#2]: https://github.com/ergebnis/composer-normalize/pull/2
@@ -694,6 +704,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#646]: https://github.com/ergebnis/composer-normalize/pull/646
 [#647]: https://github.com/ergebnis/composer-normalize/pull/647
 [#707]: https://github.com/ergebnis/composer-normalize/pull/707
+[#743]: https://github.com/ergebnis/composer-normalize/pull/743
 
 [@core23]: https://github.com/core23
 [@dependabot]: https://github.com/dependabot


### PR DESCRIPTION
This pull request

* [x] requires `composer/composer:2.0.13` for `composer-normalize.phar`

Fixes #736.