### PR TITLE
Remove trailing comma from `composer.json` README.md usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ As an alternative to specifying the `--indent-size` and `--indent-style` options
   "extra": {
     "composer-normalize": {
       "indent-size": 2,
-      "indent-style": "space",
+      "indent-style": "space"
     }
   }
 }


### PR DESCRIPTION
Whilst setting up this I copied and pasted the `extra` config into my `composer.json` file and resulted in:

```shell
❯ composer normalize --dry-run

                                                                    
  [Seld\JsonLint\ParsingException]                                  
  "./composer.json" does not contain valid JSON                     
  Parse error on line 9:                                            
  ...": "space",        }      }}                                   
  ---------------------^                                            
  Expected: 'STRING' - It appears you have an extra trailing comma  
```

This pull request resolves the above scenario


* [x] 

Follows #.
Related to #.
Fixes #.
