### PR TITLE
Updated `README.md` - optimize console command's

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,7 +21,7 @@ We are using [`yamllint`](https://github.com/adrienverge/yamllint) to enforce co
 If you do not have `yamllint` installed yet, run
 
 ```sh
-$ brew install yamllint
+brew install yamllint
 ```
 
 to install `yamllint`.
@@ -31,7 +31,7 @@ We are using [`friendsofphp/php-cs-fixer`](https://github.com/FriendsOfPHP/PHP-C
 Run
 
 ```sh
-$ make coding-standards
+make coding-standards
 ```
 
 to automatically fix coding standard violations.
@@ -43,7 +43,7 @@ We are using [`maglnet/composer-require-checker`](https://github.com/maglnet/Com
 Run
 
 ```sh
-$ make dependency-analysis
+make dependency-analysis
 ```
 
 to run a dependency analysis.
@@ -55,7 +55,7 @@ We are using [`phpstan/phpstan`](https://github.com/phpstan/phpstan) and [`vimeo
 Run
 
 ```sh
-$ make static-code-analysis
+make static-code-analysis
 ```
 
 to run a static code analysis.
@@ -65,7 +65,7 @@ We are also using the baseline features of [`phpstan/phpstan`](https://medium.co
 Run
 
 ```sh
-$ make static-code-analysis-baseline
+make static-code-analysis-baseline
 ```
 
 to regenerate the baselines in [`../phpstan-baseline.neon`](../phpstan-baseline.neon) and [`../psalm-baseline.xml`](../psalm-baseline.xml).
@@ -79,7 +79,7 @@ We are using [`phpunit/phpunit`](https://github.com/sebastianbergmann/phpunit) t
 Run
 
 ```sh
-$ make tests
+make tests
 ```
 
 to run all the tests.
@@ -89,7 +89,7 @@ to run all the tests.
 Run
 
 ```sh
-$ make
+make
 ```
 
 to enforce coding standards, run a static code analysis, and run tests!
@@ -99,7 +99,7 @@ to enforce coding standards, run a static code analysis, and run tests!
 :bulb: Run
 
 ```sh
-$ make help
+make help
 ```
 
 to display a list of available targets with corresponding descriptions.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ When it comes to formatting `composer.json`, you have the following options:
 
 Run
 
-```
-$ composer require --dev ergebnis/composer-normalize
+```console
+composer require --dev ergebnis/composer-normalize
 ```
 
 to install `ergebnis/composer-normalize` as a composer plugin.
@@ -46,8 +46,8 @@ Head over to http://github.com/ergebnis/composer-normalize/releases/latest and d
 
 Run
 
-```
-$ chmod +x composer-normalize.phar
+```console
+chmod +x composer-normalize.phar
 ```
 
 to make the downloaded `composer-normalize.phar` executable.
@@ -56,8 +56,8 @@ to make the downloaded `composer-normalize.phar` executable.
 
 Run
 
-```
-$ phive install ergebnis/composer-normalize
+```console
+phive install ergebnis/composer-normalize
 ```
 
 to install `ergebnis/composer-normalize` with [PHIVE](https://phar.io).
@@ -68,8 +68,8 @@ to install `ergebnis/composer-normalize` with [PHIVE](https://phar.io).
 
 Run
 
-```
-$ composer normalize
+```console
+composer normalize
 ```
 
 to normalize `composer.json` in the working directory.
@@ -78,8 +78,8 @@ to normalize `composer.json` in the working directory.
 
 Run
 
-```
-$ ./composer-normalize.phar
+```console
+./composer-normalize.phar
 ```
 
 to normalize `composer.json` in the working directory.
@@ -88,8 +88,8 @@ to normalize `composer.json` in the working directory.
 
 Run
 
-```
-$ ./tools/composer-normalize
+```console
+./tools/composer-normalize
 ```
 
 to normalize `composer.json` in the working directory.
@@ -137,8 +137,8 @@ As an alternative to specifying the `--indent-size` and `--indent-style` options
 
 If you want to run this in continuous integration services, use the `--dry-run` option.
 
-```
-$ composer normalize --dry-run
+```console
+composer normalize --dry-run
 ```
 
 In case `composer.json` is not normalized (or `composer.lock` is not up-to-date), the command will
@@ -216,8 +216,8 @@ sections, the `VersionConstraintNormalizer` will ensure that
 
 Running
 
-```
-$ composer normalize
+```console
+composer normalize
 ```
 
 against https://github.com/pestphp/pest/blob/v0.3.19/composer.json yields the following diff:
@@ -322,8 +322,8 @@ index 1cfbf1e..204f20f 100644
 
 Running
 
-```
-$ composer normalize
+```console
+composer normalize
 ```
 
 against https://github.com/phpspec/phpspec/blob/7.0.1/composer.json yields the following diff:
@@ -457,8 +457,8 @@ index 90150a37..276a2ecd 100644
 
 Running
 
-```
-$ composer normalize
+```console
+composer normalize
 ```
 
 against https://github.com/phpspec/phpspec/blob/7.0.1/composer.json yields the following diff:


### PR DESCRIPTION
The previous console commands, made it impossible to use the GUI copy function as intended:

If someone clicked on the "copy" button to the right of the command, then not only the command was copied, but also the preceding "$" character.

The unnecessary character was removed from all commands and the usual Markdown tag "console" was added.

This pull request is also related to file: "/.github/CONTRIBUTING.md". Please let me know if you want me to revise this file as well.
