### PR TITLE
Fix: Use dashes instead of asterisks for unordered lists

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -44,7 +44,7 @@ jobs:
           body: |
             This PR
 
-            * [x] updates `schema.json`
+            - [x] updates `schema.json`
           commit-message: "Enhancement: Update schema.json"
           path: "resource/"
           title: "Enhancement: Update schema.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ For a full diff see [`2.15.0...2.16.0`][2.15.0...2.16.0].
 
 ### Changed
 
-* Required `composer/composer:2.1.12` for compiling `composer-normalize.phar` ([#804]), by [@localheinz]
-* Dropped support for `composer/composer:^1.0.0` ([#807]), by [@localheinz]
+- Required `composer/composer:2.1.12` for compiling `composer-normalize.phar` ([#804]), by [@localheinz]
+- Dropped support for `composer/composer:^1.0.0` ([#807]), by [@localheinz]
 
 ## [`2.15.0`][2.15.0]
 
@@ -23,7 +23,7 @@ For a full diff see [`2.14.0...2.15.0`][2.14.0...2.15.0].
 
 ### Changed
 
-* Updated `schema.json` ([#754]), by [@ergebnis-bot]
+- Updated `schema.json` ([#754]), by [@ergebnis-bot]
 
 ## [`2.14.0`][2.14.0]
 
@@ -31,11 +31,11 @@ For a full diff see [`2.13.4...2.14.0`][2.13.4...2.14.0].
 
 ### Changed
 
-* Updated `schema.json` ([#744]), by [@ergebnis-bot]
+- Updated `schema.json` ([#744]), by [@ergebnis-bot]
 
 ### Fixed
 
-* Updated `composer/composer` ([#750]), by [@localheinz]
+- Updated `composer/composer` ([#750]), by [@localheinz]
 
 ## [`2.13.4`][2.13.4]
 
@@ -43,7 +43,7 @@ For a full diff see [`2.13.3...2.13.4`][2.13.3...2.13.4].
 
 ### Fixed
 
-* Required `composer/composer:2.0.13` for compiling `composer-normalize.phar` ([#743]), by [@localheinz]
+- Required `composer/composer:2.0.13` for compiling `composer-normalize.phar` ([#743]), by [@localheinz]
 
 ## [`2.13.3`][2.13.3]
 
@@ -51,7 +51,7 @@ For a full diff see [`2.13.2...2.13.3`][2.13.2...2.13.3].
 
 ### Fixed
 
-* Required `ergebnis/json-normalizer:^1.0.3` which correctly sorts `composer-plugin-api` ([#707]), by [@dependabot]
+- Required `ergebnis/json-normalizer:^1.0.3` which correctly sorts `composer-plugin-api` ([#707]), by [@dependabot]
 
 ## [`2.13.2`][2.13.2]
 
@@ -59,13 +59,13 @@ For a full diff see [`2.13.1...2.13.2`][2.13.1...2.13.2].
 
 ### Fixed
 
-* Required `ergebnis/json-normalizer:^1.0.2` which ignores the `config.preferred-install` hash only instead of all properties with the name `preferred-install` ([#647]), by [@localheinz]
+- Required `ergebnis/json-normalizer:^1.0.2` which ignores the `config.preferred-install` hash only instead of all properties with the name `preferred-install` ([#647]), by [@localheinz]
 
 ## [`2.13.1`][2.13.1]
 
 For a full diff see [`2.13.0...2.13.1`][2.13.0...2.13.1].
 
-:clown_face: Made a mistake tagging this release *before* pulling changes merged into `main`.
+:clown_face: Made a mistake tagging this release *before- pulling changes merged into `main`.
 
 ## [`2.13.0`][2.13.0]
 
@@ -73,7 +73,7 @@ For a full diff see [`2.12.2...2.13.0`][2.12.2...2.13.0].
 
 ### Changed
 
-* Brought back support for `composer/composer:^1.0.0` ([#644]), by [@localheinz]
+- Brought back support for `composer/composer:^1.0.0` ([#644]), by [@localheinz]
 
 ## [`2.12.2`][2.12.2]
 
@@ -81,7 +81,7 @@ For a full diff see [`2.12.1...2.12.2`][2.12.1...2.12.2].
 
 ### Fixed
 
-* Required `ergebnis/json-normalizer:^1.0.1` which ignores the `preferred-install` hash when sorting configuration hashes by key ([#646]), by [@dependabot]
+- Required `ergebnis/json-normalizer:^1.0.1` which ignores the `preferred-install` hash when sorting configuration hashes by key ([#646]), by [@dependabot]
 
 ## [`2.12.1`][2.12.1]
 
@@ -89,7 +89,7 @@ For a full diff see [`2.12.0...2.12.1`][2.12.0...2.12.1].
 
 ### Fixed
 
-* Show version of plugin instead of version of `Composer\Console\Application` when running as development dependency ([#643]), by [@localheinz]
+- Show version of plugin instead of version of `Composer\Console\Application` when running as development dependency ([#643]), by [@localheinz]
 
 ## [`2.12.0`][2.12.0]
 
@@ -97,15 +97,15 @@ For a full diff see [`2.11.0...2.12.0`][2.11.0...2.12.0].
 
 ### Added
 
-* Started showing plugin and author name when running `composer normalize` ([#641]), by [@localheinz]
+- Started showing plugin and author name when running `composer normalize` ([#641]), by [@localheinz]
 
 ### Changed
 
-* Required `ergebnis/json-normalizer:^1.0.0` which allows recursively sorting config hashes ([#634]), by [@dependabot]
+- Required `ergebnis/json-normalizer:^1.0.0` which allows recursively sorting config hashes ([#634]), by [@dependabot]
 
 ### Fixed
 
-* Required `composer/composer:2.0.8` for `composer-normalize.phar` ([#640]), by [@localheinz]
+- Required `composer/composer:2.0.8` for `composer-normalize.phar` ([#640]), by [@localheinz]
 
 ## [`2.11.0`][2.11.0]
 
@@ -113,7 +113,7 @@ For a full diff see [`2.10.0...2.11.0`][2.10.0...2.11.0].
 
 ### Changed
 
-* Updated `schema.json` ([#615]), by [@ergebnis-bot]
+- Updated `schema.json` ([#615]), by [@ergebnis-bot]
 
 ## [`2.10.0`][2.10.0]
 
@@ -121,7 +121,7 @@ For a full diff see [`2.9.1...2.10.0`][2.9.1...2.10.0].
 
 ### Added
 
-* Allowed configuration via composer extra ([#608]), by [@localheinz]
+- Allowed configuration via composer extra ([#608]), by [@localheinz]
 
 ## [`2.9.1`][2.9.1]
 
@@ -129,8 +129,8 @@ For a full diff see [`2.9.0...2.9.1`][2.9.0...2.9.1].
 
 ### Fixed
 
-* Required at least `composer/composer:^1.10.17` and used `composer/composer:1.10.17` for `composer-normalize.phar` ([#596]), by [@localheinz]
-* Dropped support for `composer/composer:^1.0.0` ([#597]), by [@localheinz]
+- Required at least `composer/composer:^1.10.17` and used `composer/composer:1.10.17` for `composer-normalize.phar` ([#596]), by [@localheinz]
+- Dropped support for `composer/composer:^1.0.0` ([#597]), by [@localheinz]
 
 ## [`2.9.0`][2.9.0]
 
@@ -138,11 +138,11 @@ For a full diff see [`2.8.2...2.9.0`][2.8.2...2.9.0].
 
 ### Changed
 
-* Updated `schema.json` ([#572]), by [@ergebnis-bot]
+- Updated `schema.json` ([#572]), by [@ergebnis-bot]
 
 ### Fixed
 
-* Required at least `composer/composer:^1.10.15` and used `composer/composer:1.10.15` for `composer-normalize.phar` ([#582]), by [@localheinz]
+- Required at least `composer/composer:^1.10.15` and used `composer/composer:1.10.15` for `composer-normalize.phar` ([#582]), by [@localheinz]
 
 ## [`2.8.2`][2.8.2]
 
@@ -150,7 +150,7 @@ For a full diff see [`2.8.1...2.8.2`][2.8.1...2.8.2].
 
 ### Changed
 
-* Require at least `composer/composer:^1.10.13` ([#554]), by [@localheinz]
+- Require at least `composer/composer:^1.10.13` ([#554]), by [@localheinz]
 
 ## [`2.8.1`][2.8.1]
 
@@ -158,7 +158,7 @@ For a full diff see [`2.8.0...2.8.1`][2.8.0...2.8.1].
 
 ### Changed
 
-* Dropped support for PHP 7.1 ([#529]), by [@localheinz]
+- Dropped support for PHP 7.1 ([#529]), by [@localheinz]
 
 ## [`2.8.0`][2.8.0]
 
@@ -166,7 +166,7 @@ For a full diff see [`2.7.0...2.8.0`][2.7.0...2.8.0].
 
 ### Changed
 
-* Updated `schema.json` ([#526]), by [@ergebnis-bot]
+- Updated `schema.json` ([#526]), by [@ergebnis-bot]
 
 ## [`2.7.0`][2.7.0]
 
@@ -174,11 +174,11 @@ For a full diff see [`2.6.1...2.7.0`][2.6.1...2.7.0].
 
 ### Added
 
-* Added `--no-check-lock` option which allows skipping validation of `composer.lock` ([#515]), by [@localheinz]
+- Added `--no-check-lock` option which allows skipping validation of `composer.lock` ([#515]), by [@localheinz]
 
 ### Changed
 
-* Updated `schema.json` ([#512]), by [@ergebnis-bot]
+- Updated `schema.json` ([#512]), by [@ergebnis-bot]
 
 ## [`2.6.1`][2.6.1]
 
@@ -186,7 +186,7 @@ For a full diff see [`2.6.0...2.6.1`][2.6.0...2.6.1].
 
 ### Fixed
 
-* Added support for PHP 8.0, for real ([#484], [#485], [#487]), by [@dependabot]
+- Added support for PHP 8.0, for real ([#484], [#485], [#487]), by [@dependabot]
 
 ## [`2.6.0`][2.6.0]
 
@@ -194,7 +194,7 @@ For a full diff see [`2.5.2...2.6.0`][2.5.2...2.6.0].
 
 ### Added
 
-* Added support for PHP 8.0 ([#465]), by [@core23]
+- Added support for PHP 8.0 ([#465]), by [@core23]
 
 ## [`2.5.2`][2.5.2]
 
@@ -202,7 +202,7 @@ For a full diff see [`2.5.1...2.5.2`][2.5.1...2.5.2].
 
 ### Fixed
 
-* Started ignoring platform requirements when updating the lock file ([#481]), by [@localheinz]
+- Started ignoring platform requirements when updating the lock file ([#481]), by [@localheinz]
 
 ## [`2.5.1`][2.5.1]
 
@@ -210,9 +210,9 @@ For a full diff see [`2.5.0...2.5.1`][2.5.0...2.5.1].
 
 ### Fixed
 
-* Started updating lock files with a new `Composer\Console\Application` instead of reusing the current instance ([#420]), by [@localheinz]
-* Stopped using the deprecated `--no-suggest` option when updating the lock file ([#422]), by [@localheinz]
-* Started relaxing schema in place to avoid issues resolving references and the like on Windows ([#424]), by [@localheinz]
+- Started updating lock files with a new `Composer\Console\Application` instead of reusing the current instance ([#420]), by [@localheinz]
+- Stopped using the deprecated `--no-suggest` option when updating the lock file ([#422]), by [@localheinz]
+- Started relaxing schema in place to avoid issues resolving references and the like on Windows ([#424]), by [@localheinz]
 
 ## [`2.5.0`][2.5.0]
 
@@ -220,7 +220,7 @@ For a full diff see [`2.4.0...2.5.0`][2.4.0...2.5.0].
 
 ### Changed
 
-* Apply lax validation to `composer.json` ([#416]), by [@localheinz]
+- Apply lax validation to `composer.json` ([#416]), by [@localheinz]
 
 ## [`2.4.0`][2.4.0]
 
@@ -228,8 +228,8 @@ For a full diff see [`2.3.2...2.4.0`][2.3.2...2.4.0].
 
 ### Changed
 
-* Started showing validation error messages as obtained from validation instead of relying on on executing composer validate ([#406]), by [@localheinz]
-* Made plugin compatible with `composer/composer:^2.0.0`  ([#412]), by [@localheinz]
+- Started showing validation error messages as obtained from validation instead of relying on on executing composer validate ([#406]), by [@localheinz]
+- Made plugin compatible with `composer/composer:^2.0.0`  ([#412]), by [@localheinz]
 
 ## [`2.3.2`][2.3.2]
 
@@ -237,7 +237,7 @@ For a full diff see [`2.3.1...2.3.2`][2.3.1...2.3.2].
 
 ### Fixed
 
-* Fixed a reference that prevented an upload of release assets ([#380]), by [@localheinz]
+- Fixed a reference that prevented an upload of release assets ([#380]), by [@localheinz]
 
 ## [`2.3.1`][2.3.1]
 
@@ -245,7 +245,7 @@ For a full diff see [`2.3.0...2.3.1`][2.3.0...2.3.1].
 
 ### Fixed
 
-* Updated `composer/composer` ([#379]), by [@localheinz]
+- Updated `composer/composer` ([#379]), by [@localheinz]
 
 ## [`2.3.0`][2.3.0]
 
@@ -253,7 +253,7 @@ For a full diff see [`2.2.4...2.3.0`][2.2.4...2.3.0].
 
 ### Changed
 
-* Updated `schema.json` ([#374]), by [@ergebnis-bot]
+- Updated `schema.json` ([#374]), by [@ergebnis-bot]
 
 ## [`2.2.4`][2.2.4]
 
@@ -261,7 +261,7 @@ For a full diff see [`2.2.3...2.2.4`][2.2.3...2.2.4].
 
 ### Fixed
 
-* Use real path to `schema.json` ([#364]), by [@localheinz]
+- Use real path to `schema.json` ([#364]), by [@localheinz]
 
 ## [`2.2.3`][2.2.3]
 
@@ -269,7 +269,7 @@ For a full diff see [`2.2.2...2.2.3`][2.2.2...2.2.3].
 
 ### Changed
 
-* Updated `schema.json` ([#354]), by [@ergebnis-bot]
+- Updated `schema.json` ([#354]), by [@ergebnis-bot]
 
 ## [`2.2.2`][2.2.2]
 
@@ -277,7 +277,7 @@ For a full diff see [`2.2.1...2.2.2`][2.2.1...2.2.2].
 
 ### Changed
 
-* Updated `schema.json` ([#322]), by [@localheinz]
+- Updated `schema.json` ([#322]), by [@localheinz]
 
 ## [`2.2.1`][2.2.1]
 
@@ -285,7 +285,7 @@ For a full diff see [`2.2.0...2.2.1`][2.2.0...2.2.1].
 
 ### Changed
 
-* Removed dependency on `ergebnis/composer-json-normalizer` ([#316]), by [@localheinz]
+- Removed dependency on `ergebnis/composer-json-normalizer` ([#316]), by [@localheinz]
 
 ## [`2.2.0`][2.2.0]
 
@@ -293,7 +293,7 @@ For a full diff see [`2.1.2...2.2.0`][2.1.2...2.2.0].
 
 ### Added
 
-* Added `--diff` option ([#303]), by [@localheinz]
+- Added `--diff` option ([#303]), by [@localheinz]
 
 ## [`2.1.2`][2.1.2]
 
@@ -301,7 +301,7 @@ For a full diff see [`2.1.1...2.1.2`][2.1.1...2.1.2].
 
 ### Fixed
 
-* Allow passing argument and options to the command ([#301]), by [@localheinz]
+- Allow passing argument and options to the command ([#301]), by [@localheinz]
 
 ## [`2.1.1`][2.1.1]
 
@@ -309,7 +309,7 @@ For a full diff see [`2.1.0...2.1.1`][2.1.0...2.1.1].
 
 ### Fixed
 
-* Actually run `composer validate` to show validation errors when `composer.json` is not valid according to its schema ([#297]), by [@localheinz]
+- Actually run `composer validate` to show validation errors when `composer.json` is not valid according to its schema ([#297]), by [@localheinz]
 
 ## [`2.1.0`][2.1.0]
 
@@ -317,7 +317,7 @@ For a full diff see [`2.0.2...2.1.0`][2.0.2...2.1.0].
 
 ### Added
 
-* Started compiling, signing, and uploading `composer-normalize.phar` and `composer-normalize.phar.asc` to release assets when a tag is pushed ([#292]), by [@localheinz]
+- Started compiling, signing, and uploading `composer-normalize.phar` and `composer-normalize.phar.asc` to release assets when a tag is pushed ([#292]), by [@localheinz]
 
 ## [`2.0.2`][2.0.2]
 
@@ -325,7 +325,7 @@ For a full diff see [`2.0.1...2.0.2`][2.0.1...2.0.2].
 
 ### Fixed
 
-* Brought back support for PHP 7.1 ([#280]), by [@localheinz]
+- Brought back support for PHP 7.1 ([#280]), by [@localheinz]
 
 ## [`2.0.1`][2.0.1]
 
@@ -333,7 +333,7 @@ For a full diff see [`2.0.0...2.0.1`][2.0.0...2.0.1]
 
 ## Changed
 
-* Removed `Ergebnis\Composer\Normalize\Command\SchemaUriResolver` and checked in `schema.json` instead ([#273]), by [@localheinz]
+- Removed `Ergebnis\Composer\Normalize\Command\SchemaUriResolver` and checked in `schema.json` instead ([#273]), by [@localheinz]
 
 ## [`2.0.0`][2.0.0]
 
@@ -341,9 +341,9 @@ For a full diff see [`1.3.1...2.0.0`][1.3.1...2.0.0].
 
 ## Changed
 
-* Started using `ergebnis/composer-json-normalizer` instead of `localheinz/composer-json-normalizer`, `ergebnis/json-normalizer` instead of `localheinz/json-normalizer`, and `ergebnis/json-printer` instead of `localheinz/json-printer` ([#261]), by [@localheinz]
-* Removed default values for parameters `$formatter` and `$differ` of constructor of `Ergebnis\Composer\Normalize\Command\NormalizeCommand`  ([#262]), by [@localheinz]
-* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#267]), by [@localheinz]
+- Started using `ergebnis/composer-json-normalizer` instead of `localheinz/composer-json-normalizer`, `ergebnis/json-normalizer` instead of `localheinz/json-normalizer`, and `ergebnis/json-printer` instead of `localheinz/json-printer` ([#261]), by [@localheinz]
+- Removed default values for parameters `$formatter` and `$differ` of constructor of `Ergebnis\Composer\Normalize\Command\NormalizeCommand`  ([#262]), by [@localheinz]
+- Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#267]), by [@localheinz]
 
   Run
 
@@ -374,11 +374,11 @@ For a full diff see [`1.3.1...2.0.0`][1.3.1...2.0.0].
   ```
 
   to delete backup files created in the previous step.
-* Marked `Ergebnis\Composer\Normalize\Command\NormalizeCommand` and `Ergebnis\Composer\Normalize\Command\SchemaUriResolver` as internal to allow modifications without the need for major releases ([#270]), by [@localheinz]
+- Marked `Ergebnis\Composer\Normalize\Command\NormalizeCommand` and `Ergebnis\Composer\Normalize\Command\SchemaUriResolver` as internal to allow modifications without the need for major releases ([#270]), by [@localheinz]
 
 ### Fixed
 
-* Dropped support for PHP 7.1 ([#235]), by [@localheinz]
+- Dropped support for PHP 7.1 ([#235]), by [@localheinz]
 
 ## [`1.3.1`][1.3.1]
 
@@ -386,7 +386,7 @@ For a full diff see [`1.3.0...1.3.1`][1.3.0...1.3.1].
 
 ### Fixed
 
-* Started using `localheinz/diff` to avoid issues using `sebastian/diff` ([#207]), by [@localheinz]
+- Started using `localheinz/diff` to avoid issues using `sebastian/diff` ([#207]), by [@localheinz]
 
 ## [`1.3.0`][1.3.0]
 
@@ -394,7 +394,7 @@ For a full diff see [`1.2.0...1.3.0`][1.2.0...1.3.0].
 
 ### Changed
 
-* Resolve local and fall back to remote schema so that command works offline and behind proxies ([#190]), by [@localheinz]
+- Resolve local and fall back to remote schema so that command works offline and behind proxies ([#190]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -402,7 +402,7 @@ For a full diff see [`1.1.4...1.2.0`][1.1.4...1.2.0].
 
 ### Changed
 
-* Started using the `StrictUnifiedDiffOutputBuilder` when available to create more condensed diffs when using the `--dry-run` option ([#80]), by [@localheinz]
+- Started using the `StrictUnifiedDiffOutputBuilder` when available to create more condensed diffs when using the `--dry-run` option ([#80]), by [@localheinz]
 
 ## [`1.1.4`][1.1.4]
 
@@ -410,7 +410,7 @@ For a full diff see [`1.1.3...1.1.4`][1.1.3...1.1.4].
 
 ### Fixed
 
-* Removed requirement for `composer.json` to be writable when using the `--dry-run` option ([#177]), by [@localheinz]
+- Removed requirement for `composer.json` to be writable when using the `--dry-run` option ([#177]), by [@localheinz]
 
 ## [`1.1.3`][1.1.3]
 
@@ -418,7 +418,7 @@ For a full diff see [`1.1.2...1.1.3`][1.1.2...1.1.3].
 
 ### Fixed
 
-* Reversed use of red and green for rendering diff when using the `--dry-run` option ([#173]), by [@TravisCarden]
+- Reversed use of red and green for rendering diff when using the `--dry-run` option ([#173]), by [@TravisCarden]
 
 ## [`1.1.2`][1.1.2]
 
@@ -426,7 +426,7 @@ For a full diff see [`1.1.1...1.1.2`][1.1.1...1.1.2].
 
 ### Fixed
 
-* Reverted deprecation of the `file` argument of the `NormalizeCommand` as it turns out that the same functionality can _not_ be achieved using the `--working-dir` option ([#166]), by [@localheinz]
+- Reverted deprecation of the `file` argument of the `NormalizeCommand` as it turns out that the same functionality can _not_ be achieved using the `--working-dir` option ([#166]), by [@localheinz]
 
 ## [`1.1.1`][1.1.1]
 
@@ -434,7 +434,7 @@ For a full diff see [`1.1.0...1.1.1`][1.1.0...1.1.1].
 
 ### Removed
 
-* Updated [`localheinz/composer-json-normalizer`](http://github.com/localheinz/composer-json-normalizer), which effectively removed a dependency on [`composer/composer`](https://github.com/composer/composer) ([#157]), by [@localheinz]
+- Updated [`localheinz/composer-json-normalizer`](http://github.com/localheinz/composer-json-normalizer), which effectively removed a dependency on [`composer/composer`](https://github.com/composer/composer) ([#157]), by [@localheinz]
 
 ## [`1.1.0`][1.1.0]
 
@@ -442,11 +442,11 @@ For a full diff see [`1.0.0...1.1.0`][1.0.0...1.1.0].
 
 ### Deprecated
 
-* Deprecated the `file` argument of the `NormalizeCommand` as the same functionality can be achieved using the `--working-dir` option ([#145]), by [@localheinz]
+- Deprecated the `file` argument of the `NormalizeCommand` as the same functionality can be achieved using the `--working-dir` option ([#145]), by [@localheinz]
 
 ### Fixed
 
-* Force reading `composer.json` and `composer.lock` after normalization to ensure `composer.lock` is updated when not fresh after normalization ([#139]), by [@localheinz]
+- Force reading `composer.json` and `composer.lock` after normalization to ensure `composer.lock` is updated when not fresh after normalization ([#139]), by [@localheinz]
 
 ## [`1.0.0`][1.0.0]
 
@@ -454,11 +454,11 @@ For a full diff see [`0.9.0...1.0.0`][0.9.0...1.0.0].
 
 ### Added
 
-* Added this changelog ([#94]), by [@localheinz]
+- Added this changelog ([#94]), by [@localheinz]
 
 ### Removed
 
-* Removed normalizers after extracting package [`localheinz/composer-json-normalizer`](https://github.com/localheinz/composer-json-normalizer) ([#106]), by [@localheinz]
+- Removed normalizers after extracting package [`localheinz/composer-json-normalizer`](https://github.com/localheinz/composer-json-normalizer) ([#106]), by [@localheinz]
 
 ## [`0.9.0`][0.9.0]
 
@@ -466,11 +466,11 @@ For a full diff see [`0.8.0...0.9.0`][0.8.0...0.9.0].
 
 ### Changed
 
-* The `ConfigHashNormalizer` now also sorts the `scripts-descriptions` section ([#89]), by [@localheinz]
+- The `ConfigHashNormalizer` now also sorts the `scripts-descriptions` section ([#89]), by [@localheinz]
 
 ### Fixed
 
-* When validation of `composer.lock` fails prior to normalization, it is now recommended to update the lock file only ([#86]), by [@svenluijten]
+- When validation of `composer.lock` fails prior to normalization, it is now recommended to update the lock file only ([#86]), by [@svenluijten]
 
 ## [`0.8.0`][0.8.0]
 
@@ -478,7 +478,7 @@ For a full diff see [`0.7.0...0.8.0`][0.7.0...0.8.0].
 
 ### Changed
 
-* The `ConfigHashNormalizer` now also sorts the `extra` section ([#60]), by [@localheinz]
+- The `ConfigHashNormalizer` now also sorts the `extra` section ([#60]), by [@localheinz]
 
 ## [`0.7.0`][0.7.0]
 
@@ -486,7 +486,7 @@ For a full diff see [`0.6.0...0.7.0`][0.6.0...0.7.0].
 
 ### Changed
 
-* Updated `localheinz/json-normalizer`, which now sniffs the new-line character and uses it for printing instead of using `PHP_EOL` ([#62]), by [@localheinz]
+- Updated `localheinz/json-normalizer`, which now sniffs the new-line character and uses it for printing instead of using `PHP_EOL` ([#62]), by [@localheinz]
 
 ## [`0.6.0`][0.6.0]
 
@@ -494,7 +494,7 @@ For a full diff see [`0.5.0...0.6.0`][0.5.0...0.6.0].
 
 ### Added
 
-* Added a `file` argument to the `NormalizeCommand`, so the path to `composer.json` can be specified now, ([#51]), by [@localheinz]
+- Added a `file` argument to the `NormalizeCommand`, so the path to `composer.json` can be specified now, ([#51]), by [@localheinz]
 
 ## [`0.5.0`][0.5.0]
 
@@ -502,7 +502,7 @@ For a full diff see [`0.4.0...0.5.0`][0.4.0...0.5.0].
 
 ### Changed
 
-* Updated `localheinz/json-normalizer`, which significantly improves the `SchemaNormalizer` employed to do the major normalization of `composer.json` ([#42]), by [@localheinz]
+- Updated `localheinz/json-normalizer`, which significantly improves the `SchemaNormalizer` employed to do the major normalization of `composer.json` ([#42]), by [@localheinz]
 
 ## [`0.4.0`][0.4.0]
 
@@ -510,7 +510,7 @@ For a full diff see [`0.3.0...0.4.0`][0.3.0...0.4.0].
 
 ### Added
 
-* Added `--dry-run` option, which allows usage in Continuous Integration systems, as it renders a diff and exits with a non-zero exit code ([#38]), by [@localheinz]
+- Added `--dry-run` option, which allows usage in Continuous Integration systems, as it renders a diff and exits with a non-zero exit code ([#38]), by [@localheinz]
 
 ## [`0.3.0`][0.3.0]
 
@@ -518,7 +518,7 @@ For a full diff see [`0.2.0...0.3.0`][0.2.0...0.3.0].
 
 ### Fixed
 
-* Dropped support for PHP 7.0, which allows proper handling of empty PSR-4 namespace prefixes ([#30]), by [@localheinz]
+- Dropped support for PHP 7.0, which allows proper handling of empty PSR-4 namespace prefixes ([#30]), by [@localheinz]
 
 ## [`0.2.0`][0.2.0]
 
@@ -526,12 +526,12 @@ For a full diff see [`0.1.0...0.2.0`][0.1.0...0.2.0].
 
 ### Added
 
-* Added `--no-update-lock` option, which allows skipping the update of `composer.lock` after normalization ([#28]), by [@localheinz]
-* Added the `VersionConstraintNormalizer`, which normalizes version constraints ([#18]), by [@localheinz]
+- Added `--no-update-lock` option, which allows skipping the update of `composer.lock` after normalization ([#28]), by [@localheinz]
+- Added the `VersionConstraintNormalizer`, which normalizes version constraints ([#18]), by [@localheinz]
 
 ### Fixed
 
-* Using the `--no-scripts` option when invoking the `UpdateCommand` to update `composer.lock` ([#19]), by [@localheinz]
+- Using the `--no-scripts` option when invoking the `UpdateCommand` to update `composer.lock` ([#19]), by [@localheinz]
 
 ## [`0.1.0`][0.1.0]
 
@@ -539,12 +539,12 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 
 ### Added
 
-* Added `NormalizeCommand` ([#1]), by [@localheinz]
-* Added `ConfigHashNormalizer`, which sorts entries in the `config` section by key ([#2]), by [@localheinz]
-* Added the `NormalizePlugin`, which provides the `NormalizeCommand` ([#3]), by [@localheinz]
-* Added the `PackageHashNormalizer` which sorts packages in the `conflict`, `provide`, `replaces`, `require`, `require-dev`, and `suggest` sections using the same algorithm that is used by the `sort-packages` option of composer itself ([#6]), by [@localheinz]
-* Added the `BinNormalizer`, which sorts entries in the `bin` section by
-* Added the `ComposerJsonNormalizer`, which composes all of the above normalizers along with the `SchemaNormalizer`, to normalize `composer.json` according to its underlying JSON schema ([#8] and [#10]), by [@localheinz]
+- Added `NormalizeCommand` ([#1]), by [@localheinz]
+- Added `ConfigHashNormalizer`, which sorts entries in the `config` section by key ([#2]), by [@localheinz]
+- Added the `NormalizePlugin`, which provides the `NormalizeCommand` ([#3]), by [@localheinz]
+- Added the `PackageHashNormalizer` which sorts packages in the `conflict`, `provide`, `replaces`, `require`, `require-dev`, and `suggest` sections using the same algorithm that is used by the `sort-packages` option of composer itself ([#6]), by [@localheinz]
+- Added the `BinNormalizer`, which sorts entries in the `bin` section by
+- Added the `ComposerJsonNormalizer`, which composes all of the above normalizers along with the `SchemaNormalizer`, to normalize `composer.json` according to its underlying JSON schema ([#8] and [#10]), by [@localheinz]
 
 [0.1.0]: https://github.com/ergebnis/composer-normalize/releases/tag/0.1.0
 [0.2.0]: https://github.com/ergebnis/composer-normalize/releases/tag/0.2.0

--- a/README.md
+++ b/README.md
@@ -98,25 +98,25 @@ to normalize `composer.json` in the working directory.
 
 The `NormalizeCommand` provided by the `NormalizePlugin` within this package will
 
-* determine whether a `composer.json` exists
-* determine whether a `composer.lock` exists, and if so, whether it is up to date (unless the `--no-check-lock` option is used)
-* use [normalizers](https://github.com/ergebnis/composer-normalize#normalizers) to normalize the content of `composer.json`
-* format the normalized content (either as sniffed, or as specified using the `--indent-size` and `--indent-style` options)
-* write the normalized and formatted content of `composer.json` back to the file
-* update the hash in `composer.lock` if it exists and if an update is necessary
+- determine whether a `composer.json` exists
+- determine whether a `composer.lock` exists, and if so, whether it is up to date (unless the `--no-check-lock` option is used)
+- use [normalizers](https://github.com/ergebnis/composer-normalize#normalizers) to normalize the content of `composer.json`
+- format the normalized content (either as sniffed, or as specified using the `--indent-size` and `--indent-style` options)
+- write the normalized and formatted content of `composer.json` back to the file
+- update the hash in `composer.lock` if it exists and if an update is necessary
 
 ### Arguments
 
-* `file`: Path to `composer.json` file (optional, defaults to `composer.json` in working directory)
+- `file`: Path to `composer.json` file (optional, defaults to `composer.json` in working directory)
 
 ### Options
 
-* `--diff`: Show the results of normalizing
-* `--dry-run`: Show the results of normalizing, but do not modify any files
-* `--indent-size`: Indent size (an integer greater than 0); should be used with the `--indent-style` option
-* `--indent-style`: Indent style (one of "space", "tab"); should be used with the `--indent-size` option
-* `--no-check-lock`: Do not check if lock file is up to date
-* `--no-update-lock`: Do not update lock file if it exists
+- `--diff`: Show the results of normalizing
+- `--dry-run`: Show the results of normalizing, but do not modify any files
+- `--indent-size`: Indent size (an integer greater than 0); should be used with the `--indent-style` option
+- `--indent-style`: Indent style (one of "space", "tab"); should be used with the `--indent-size` option
+- `--no-check-lock`: Do not check if lock file is up to date
+- `--no-update-lock`: Do not update lock file if it exists
 
 As an alternative to specifying the `--indent-size` and `--indent-style` options, you can also use composer [extra](https://getcomposer.org/doc/04-schema.md#extra) to configure these options in `composer.json`:
 
@@ -148,15 +148,15 @@ fail with an exit code of `1` and show a diff.
 
 The `ComposerJsonNormalizer` composes normalizers provided by [`ergebnis/json-normalizer`](https://github.com/ergebnis/json-normalizer):
 
-* [`Ergebnis\Json\Normalizer\ChainNormalizer`](https://github.com/ergebnis/json-normalizer#chainnormalizer)
-* [`Ergebnis\Json\Normalizer\SchemaNormalizer`](https://github.com/ergebnis/json-normalizer#schemanormalizer)
+- [`Ergebnis\Json\Normalizer\ChainNormalizer`](https://github.com/ergebnis/json-normalizer#chainnormalizer)
+- [`Ergebnis\Json\Normalizer\SchemaNormalizer`](https://github.com/ergebnis/json-normalizer#schemanormalizer)
 
 as well as the following normalizers provided by this package:
 
-* [`Ergebnis\Composer\Json\Normalizer\BinNormalizer`](https://github.com/ergebnis/composer-normalize/blob/main/README.md#binnormalizer)
-* [`Ergebnis\Composer\Json\Normalizer\ConfigHashNormalizer`](https://github.com/ergebnis/composer-normalize/blob/main/README.md#confighashnormalizer)
-* [`Ergebnis\Composer\Json\Normalizer\PackageHashNormalizer`](https://github.com/ergebnis/composer-normalize/blob/main/README.md#packagehashnormalizer)
-* [`Ergebnis\Composer\Json\Normalizer\VersionConstraintNormalizer`](https://github.com/ergebnis/composer-normalize/blob/main/README.md#versionconstraintnormalizer)
+- [`Ergebnis\Composer\Json\Normalizer\BinNormalizer`](https://github.com/ergebnis/composer-normalize/blob/main/README.md#binnormalizer)
+- [`Ergebnis\Composer\Json\Normalizer\ConfigHashNormalizer`](https://github.com/ergebnis/composer-normalize/blob/main/README.md#confighashnormalizer)
+- [`Ergebnis\Composer\Json\Normalizer\PackageHashNormalizer`](https://github.com/ergebnis/composer-normalize/blob/main/README.md#packagehashnormalizer)
+- [`Ergebnis\Composer\Json\Normalizer\VersionConstraintNormalizer`](https://github.com/ergebnis/composer-normalize/blob/main/README.md#versionconstraintnormalizer)
 
 ### `BinNormalizer`
 
@@ -168,9 +168,9 @@ If `composer.json` contains an array of scripts in the `bin` section, the `BinNo
 
 If `composer.json` contains any configuration in the
 
-* `config`
-* `extra`
-* `scripts-descriptions`
+- `config`
+- `extra`
+- `scripts-descriptions`
 
 sections, the `ConfigHashNormalizer` will sort the content of these sections by key in ascending order.
 
@@ -180,12 +180,12 @@ sections, the `ConfigHashNormalizer` will sort the content of these sections by 
 
 If `composer.json` contains any configuration in the
 
-* `conflict`
-* `provide`
-* `replace`
-* `require`
-* `require-dev`
-* `suggest`
+- `conflict`
+- `provide`
+- `replace`
+- `require`
+- `require-dev`
+- `suggest`
 
 sections, the `PackageHashNormalizer` will sort the content of these sections.
 
@@ -195,18 +195,18 @@ sections, the `PackageHashNormalizer` will sort the content of these sections.
 
 If `composer.json` contains version constraints in the
 
-* `conflict`
-* `provide`
-* `replace`
-* `require`
-* `require-dev`
+- `conflict`
+- `provide`
+- `replace`
+- `require`
+- `require-dev`
 
 sections, the `VersionConstraintNormalizer` will ensure that
 
-* all constraints are trimmed
-* *and* constraints are separated by a single space (` `) or a comma (`,`)
-* *or* constraints are separated by double-pipe with a single space before and after (` || `)
-* *range* constraints are separated by a single space (` `)
+- all constraints are trimmed
+- *and- constraints are separated by a single space (` `) or a comma (`,`)
+- *or- constraints are separated by double-pipe with a single space before and after (` || `)
+- *range- constraints are separated by a single space (` `)
 
 :bulb: Find out more about version constraints at https://getcomposer.org/doc/articles/versions.md.
 


### PR DESCRIPTION
This pull request

- [x] uses dashes instead of asterisks for unordered lists