### PR TITLE
Enhancement: Pass through select options to `UpdateCommand`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -213,7 +213,7 @@ jobs:
         run: "${{ env.COMPOSER_NORMALIZE_PHAR }} --ansi"
 
       - name: "Run composer-normalize.phar with argument and options"
-        run: "${{ env.COMPOSER_NORMALIZE_PHAR }} --ansi --dry-run composer.json"
+        run: "${{ env.COMPOSER_NORMALIZE_PHAR }} --dry-run --no-ansi composer.json"
 
   dependency-analysis:
     name: "Dependency Analysis"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`2.30.2...main`][2.30.2...main].
 
 - Updated `schema.json` ([#1070]), by [@ergebnis-bot]
 - Required `ergebnis/json-normalizer:^4.1.0` ([#1095]), by [@dependabot]
+- Started passing through `--no-ansi` option to `UpdateCommand` ([#827]), by [@localheinz]
 
 ### Fixed
 
@@ -1006,6 +1007,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#807]: https://github.com/ergebnis/composer-normalize/pull/807
 [#816]: https://github.com/ergebnis/composer-normalize/pull/816
 [#825]: https://github.com/ergebnis/composer-normalize/pull/825
+[#827]: https://github.com/ergebnis/composer-normalize/pull/827
 [#829]: https://github.com/ergebnis/composer-normalize/pull/829
 [#842]: https://github.com/ergebnis/composer-normalize/pull/842
 [#845]: https://github.com/ergebnis/composer-normalize/pull/845

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ phar: phive vendor ## Builds a phar with humbug/box
 	.phive/box info .build/phar/composer-normalize.phar
 	.build/phar/composer-normalize.phar
 	.build/phar/composer-normalize.phar --dry-run composer.json
+	.build/phar/composer-normalize.phar --dry-run --no-ansi composer.json
 
 .PHONY: phive
 phive: .phive ## Installs dependencies with phive

--- a/infection.json
+++ b/infection.json
@@ -3,8 +3,8 @@
   "logs": {
     "text": ".build/infection/infection-log.txt"
   },
-  "minCoveredMsi": 87,
-  "minMsi": 72,
+  "minCoveredMsi": 86,
+  "minMsi": 67,
   "phpUnit": {
     "configDir": "test"
   },

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -315,6 +315,7 @@ final class NormalizeCommand extends Command\BaseCommand
 
         return self::updateLockerInWorkingDirectory(
             $application,
+            $input,
             $output,
             \dirname($composerFile),
         );
@@ -513,19 +514,28 @@ final class NormalizeCommand extends Command\BaseCommand
      */
     private static function updateLockerInWorkingDirectory(
         Console\Application $application,
+        Console\Input\InputInterface $input,
         Console\Output\OutputInterface $output,
         string $workingDirectory,
     ): int {
+        $parameters = [
+            'command' => 'update',
+            '--ignore-platform-reqs' => true,
+            '--lock' => true,
+            '--no-autoloader' => true,
+            '--no-plugins' => true,
+            '--no-scripts' => true,
+            '--working-dir' => $workingDirectory,
+        ];
+
+        if ($input->hasParameterOption('--no-ansi')) {
+            $parameters = \array_merge($parameters, [
+                '--no-ansi' => true,
+            ]);
+        }
+
         return $application->run(
-            new Console\Input\ArrayInput([
-                'command' => 'update',
-                '--ignore-platform-reqs' => true,
-                '--lock' => true,
-                '--no-autoloader' => true,
-                '--no-plugins' => true,
-                '--no-scripts' => true,
-                '--working-dir' => $workingDirectory,
-            ]),
+            new Console\Input\ArrayInput($parameters),
             $output,
         );
     }


### PR DESCRIPTION
This pull request

- [x] passes through the `--no-ansi` option to the `UpdateCommand` when updating the locker

Fixes #738.