### PR TITLE
Fix: Allow `composer/package-versions-deprecated` to run as plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,9 @@
     }
   },
   "config": {
+    "allow-plugins": {
+      "composer/package-versions-deprecated": true
+    },
     "platform": {
       "php": "7.2.33"
     },


### PR DESCRIPTION
This pull request

- [x] allows `composer/package-versions-deprecated` to run as plugin