### PR TITLE
Enhancement: Use `Php74` rule set

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -26,7 +26,7 @@ $license = License\Type\MIT::markdown(
 
 $license->save();
 
-$config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php73($license->header()));
+$config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php74($license->header()));
 
 $config->getFinder()
     ->exclude([

--- a/src/Version.php
+++ b/src/Version.php
@@ -20,10 +20,8 @@ final class Version
 {
     /**
      * @see https://github.com/box-project/box/blob/master/doc/configuration.md#pretty-git-tag-placeholder-git
-     *
-     * @var string
      */
-    private static $version = '@git@';
+    private static string $version = '@git@';
 
     public static function long(): string
     {

--- a/test/Integration/Command/NormalizeCommand/AbstractTestCase.php
+++ b/test/Integration/Command/NormalizeCommand/AbstractTestCase.php
@@ -29,11 +29,7 @@ use Symfony\Component\Filesystem;
 abstract class AbstractTestCase extends Framework\TestCase
 {
     use Test\Util\Helper;
-
-    /**
-     * @var string
-     */
-    private $currentWorkingDirectory;
+    private string $currentWorkingDirectory;
 
     final protected function setUp(): void
     {

--- a/test/Integration/Command/NormalizeCommand/Normalizer/Throws/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Normalizer/Throws/Test.php
@@ -52,10 +52,7 @@ final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
         $application = self::createApplication(new NormalizeCommand(
             new Factory(),
             new class($exceptionMessage) implements Normalizer\NormalizerInterface {
-                /**
-                 * @var string
-                 */
-                private $exceptionMessage;
+                private string $exceptionMessage;
 
                 public function __construct(string $exceptionMessage)
                 {

--- a/test/Util/CommandInvocation.php
+++ b/test/Util/CommandInvocation.php
@@ -15,10 +15,7 @@ namespace Ergebnis\Composer\Normalize\Test\Util;
 
 final class CommandInvocation
 {
-    /**
-     * @var string
-     */
-    private $style;
+    private string $style;
 
     private function __construct(string $variation)
     {

--- a/test/Util/Directory.php
+++ b/test/Util/Directory.php
@@ -15,15 +15,8 @@ namespace Ergebnis\Composer\Normalize\Test\Util;
 
 final class Directory
 {
-    /**
-     * @var string
-     */
-    private $path;
-
-    /**
-     * @var bool
-     */
-    private $exists;
+    private string $path;
+    private bool $exists;
 
     private function __construct(string $path)
     {

--- a/test/Util/File.php
+++ b/test/Util/File.php
@@ -16,30 +16,44 @@ namespace Ergebnis\Composer\Normalize\Test\Util;
 final class File
 {
     private string $path;
-    private bool $exists = false;
+    private bool $exists;
     private ?string $contents;
 
-    private function __construct()
-    {
+    private function __construct(
+        string $path,
+        bool $exists,
+        ?string $contents
+    ) {
+        $this->path = $path;
+        $this->exists = $exists;
+        $this->contents = $contents;
     }
 
     public static function fromPath(string $path): self
     {
-        $file = new self();
-
-        $file->path = $path;
-
-        if (\file_exists($path)) {
-            $file->exists = true;
-
-            $contents = \file_get_contents($path);
-
-            if (\is_string($contents)) {
-                $file->contents = $contents;
-            }
+        if (!\file_exists($path)) {
+            return new self(
+                $path,
+                false,
+                null,
+            );
         }
 
-        return $file;
+        $contents = \file_get_contents($path);
+
+        if (!\is_string($contents)) {
+            return new self(
+                $path,
+                true,
+                null,
+            );
+        }
+
+        return new self(
+            $path,
+            true,
+            $contents,
+        );
     }
 
     public function path(): string

--- a/test/Util/File.php
+++ b/test/Util/File.php
@@ -15,20 +15,9 @@ namespace Ergebnis\Composer\Normalize\Test\Util;
 
 final class File
 {
-    /**
-     * @var string
-     */
-    private $path;
-
-    /**
-     * @var bool
-     */
-    private $exists = false;
-
-    /**
-     * @var null|string
-     */
-    private $contents;
+    private string $path;
+    private bool $exists = false;
+    private ?string $contents;
 
     private function __construct()
     {

--- a/test/Util/Scenario.php
+++ b/test/Util/Scenario.php
@@ -15,15 +15,8 @@ namespace Ergebnis\Composer\Normalize\Test\Util;
 
 final class Scenario
 {
-    /**
-     * @var CommandInvocation
-     */
-    private $commandInvocation;
-
-    /**
-     * @var State
-     */
-    private $initialState;
+    private CommandInvocation $commandInvocation;
+    private State $initialState;
 
     private function __construct(CommandInvocation $commandInvocation, State $initialState)
     {

--- a/test/Util/State.php
+++ b/test/Util/State.php
@@ -15,25 +15,10 @@ namespace Ergebnis\Composer\Normalize\Test\Util;
 
 final class State
 {
-    /**
-     * @var Directory
-     */
-    private $directory;
-
-    /**
-     * @var File
-     */
-    private $composerJsonFile;
-
-    /**
-     * @var File
-     */
-    private $composerLockFile;
-
-    /**
-     * @var Directory
-     */
-    private $vendorDirectory;
+    private Directory $directory;
+    private File $composerJsonFile;
+    private File $composerLockFile;
+    private Directory $vendorDirectory;
 
     private function __construct(Directory $directory)
     {


### PR DESCRIPTION
This pull request

- [x] uses the `Php74` rule set
- [x] runs `make coding-standards`
- [x] initializes properties in the constructor of a class