### PR TITLE
Fix: Create `Format` from `Json`

### DIFF
--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -222,7 +222,7 @@ final class NormalizeCommand extends Command\BaseCommand
             return 1;
         }
 
-        $format = $json->format();
+        $format = Normalizer\Format\Format::fromJson($json);
 
         if (null !== $indent) {
             $format = $format->withIndent($indent);


### PR DESCRIPTION
This pull request

- [x] creates `Format` from `Json`

Follows https://github.com/ergebnis/json-normalizer/pull/616.