### PR TITLE
Fix: Run tests with `--no-interaction` option

### DIFF
--- a/test/Util/Scenario.php
+++ b/test/Util/Scenario.php
@@ -66,12 +66,16 @@ final class Scenario
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, bool|string>
      */
     public function consoleParameters(): array
     {
         $parameters = [
             'command' => 'normalize',
+            /**
+             * @see https://github.com/composer/composer/blob/2.2.3/src/Composer/Plugin/PluginManager.php#L702-L744
+             */
+            '--no-interaction' => true,
         ];
 
         if ($this->commandInvocation->is(CommandInvocation::usingFileArgument())) {


### PR DESCRIPTION
This pull request

- [x] runs tests with the `--no-interaction` option

Follows https://github.com/composer/composer/pull/10314.

💁‍♂️ Otherwise the tests will time out, asking to confirm whether we want to allow plugins.