### PR TITLE
Fix: Allow `ergebnis/composer-normalize` to run as composer plugin

### DIFF
--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/AdditionalKeys/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/AdditionalKeys/fixture/composer.json
@@ -17,5 +17,10 @@
   "require": {
     "ext-json": "*",
     "php": "^5.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/Missing/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/Missing/fixture/composer.json
@@ -14,5 +14,10 @@
   "require": {
     "ext-json": "*",
     "php": "^5.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotGreaterThanZero/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotGreaterThanZero/fixture/composer.json
@@ -15,5 +15,10 @@
   "require": {
     "ext-json": "*",
     "php": "^5.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotInteger/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotInteger/fixture/composer.json
@@ -17,5 +17,10 @@
   "require": {
     "ext-json": "*",
     "php": "^5.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/Missing/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/Missing/fixture/composer.json
@@ -14,5 +14,10 @@
   "require": {
     "ext-json": "*",
     "php": "^5.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotSpaceOrTab/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotSpaceOrTab/fixture/composer.json
@@ -15,5 +15,10 @@
   "require": {
     "ext-json": "*",
     "php": "^5.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotString/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotString/fixture/composer.json
@@ -17,5 +17,10 @@
   "require": {
     "ext-json": "*",
     "php": "^5.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/Valid/WithOptions/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/Valid/WithOptions/fixture/composer.json
@@ -15,5 +15,10 @@
   "require": {
     "ext-json": "*",
     "php": "^5.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/Valid/WithoutOptions/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/Valid/WithoutOptions/fixture/composer.json
@@ -15,5 +15,10 @@
   "require": {
     "ext-json": "*",
     "php": "^5.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/AlreadyNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/AlreadyNormalized/fixture/composer.json
@@ -15,5 +15,10 @@
   "require": {
     "php": "^5.6",
     "ext-json": "*"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/NotYetNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/NotYetNormalized/fixture/composer.json
@@ -9,5 +9,10 @@
   "require": {
     "ext-json": "*",
     "php": "^5.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/AlreadyNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/AlreadyNormalized/fixture/composer.json
@@ -15,5 +15,10 @@
   "require": {
     "php": "^5.6",
     "ext-json": "*"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/FreshAfter/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/FreshAfter/fixture/composer.json
@@ -10,5 +10,10 @@
     "php": "^5.6",
     "ext-json": "*"
   },
-  "_comment": "This composer.json is valid according to a lax validation, a composer.lock is present and fresh before invoking the command, composer.json is not yet normalized, and composer.lock is still fresh after invoking the command."
+  "_comment": "This composer.json is valid according to a lax validation, a composer.lock is present and fresh before invoking the command, composer.json is not yet normalized, and composer.lock is still fresh after invoking the command.",
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
+  }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/NotFreshAfter/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/NotFreshAfter/fixture/composer.json
@@ -13,5 +13,10 @@
   "scripts": {
     "hello": "echo 'Hello!'"
   },
-  "_comment": "This composer.json is valid according to a lax validation, a composer.lock is present and fresh before invoking the command, composer.json is not yet normalized, and composer.lock is not fresh after invoking the command."
+  "_comment": "This composer.json is valid according to a lax validation, a composer.lock is present and fresh before invoking the command, composer.json is not yet normalized, and composer.lock is not fresh after invoking the command.",
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
+  }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/AlreadyNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/AlreadyNormalized/fixture/composer.json
@@ -15,5 +15,10 @@
   "require": {
     "php": "^5.6",
     "ext-json": "*"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/NotYetNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/NotYetNormalized/fixture/composer.json
@@ -15,5 +15,10 @@
   "require": {
     "ext-json": "*",
     "php": "^5.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithoutNoCheckLock/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithoutNoCheckLock/fixture/composer.json
@@ -15,5 +15,10 @@
   "require": {
     "php": "^5.6",
     "ext-json": "*"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Normalizer/Throws/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Normalizer/Throws/fixture/composer.json
@@ -9,5 +9,10 @@
   "require": {
     "ext-json": "*",
     "php": "^5.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Options/NotValid/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Options/NotValid/fixture/composer.json
@@ -9,5 +9,10 @@
   "require": {
     "ext-json": "*",
     "php": "^5.6"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/test/Util/Scenario.php
+++ b/test/Util/Scenario.php
@@ -72,10 +72,6 @@ final class Scenario
     {
         $parameters = [
             'command' => 'normalize',
-            /**
-             * @see https://github.com/composer/composer/blob/2.2.3/src/Composer/Plugin/PluginManager.php#L702-L744
-             */
-            '--no-interaction' => true,
         ];
 
         if ($this->commandInvocation->is(CommandInvocation::usingFileArgument())) {


### PR DESCRIPTION
This pull request

- [x] allows `ergebnis/composer-normalize` to run as composer plugin in tests

Follows #870.