### PR TITLE
Fix: Prevent updates of `ergebnis/json-normalizer` for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.23.0...main`][2.23.0...main].
+For a full diff see [`2.23.1...main`][2.23.1...main].
+
+## [`2.23.1`][2.23.1]
+
+For a full diff see [`2.23.0...2.23.1`][2.23.0...2.23.1].
 
 ### Fixed
 
 - Required `composer/composer:2.2.5` for compiling `composer-normalize.phar` ([#871]), by [@localheinz]
+- Prevented updates of `ergebnis/json-normalizer` beyond `2.1.0` for now ([#877]), by [@localheinz]
 
 ## [`2.23.0`][2.23.0]
 
@@ -678,6 +683,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [2.21.0]: https://github.com/ergebnis/composer-normalize/releases/tag/2.21.0
 [2.22.0]: https://github.com/ergebnis/composer-normalize/releases/tag/2.22.0
 [2.23.0]: https://github.com/ergebnis/composer-normalize/releases/tag/2.23.0
+[2.23.1]: https://github.com/ergebnis/composer-normalize/releases/tag/2.23.1
 
 [81bc3a8...0.1.0]: https://github.com/ergebnis/composer-normalize/compare/81bc3a8...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/composer-normalize/compare/0.1.0...0.2.0
@@ -743,7 +749,8 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [2.20.0...2.21.0]: https://github.com/ergebnis/composer-normalize/compare/2.20.0...2.21.0
 [2.21.0...2.22.0]: https://github.com/ergebnis/composer-normalize/compare/2.21.0...2.22.0
 [2.22.0...2.23.0]: https://github.com/ergebnis/composer-normalize/compare/2.22.0...2.23.0
-[2.23.0...main]: https://github.com/ergebnis/composer-normalize/compare/2.23.0...main
+[2.23.0...2.23.1]: https://github.com/ergebnis/composer-normalize/compare/2.23.0...2.23.1
+[2.23.1...main]: https://github.com/ergebnis/composer-normalize/compare/2.23.1...main
 
 [#1]: https://github.com/ergebnis/composer-normalize/pull/1
 [#2]: https://github.com/ergebnis/composer-normalize/pull/2
@@ -837,6 +844,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#863]: https://github.com/ergebnis/composer-normalize/pull/863
 [#864]: https://github.com/ergebnis/composer-normalize/pull/864
 [#871]: https://github.com/ergebnis/composer-normalize/pull/871
+[#875]: https://github.com/ergebnis/composer-normalize/pull/875
 
 [@core23]: https://github.com/core23
 [@dependabot]: https://github.com/dependabot

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "composer-plugin-api": "^2.0.0",
-    "ergebnis/json-normalizer": "^2.1.0",
+    "ergebnis/json-normalizer": "~2.1.0",
     "ergebnis/json-printer": "^3.2.0",
     "justinrainbow/json-schema": "^5.2.11",
     "localheinz/diff": "^1.1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a9e51d184fe74d4e4f167a35025187f",
+    "content-hash": "de8c9db9d8fed392a00420f7991d6ab6",
     "packages": [
         {
             "name": "ergebnis/json-normalizer",

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/AdditionalKeys/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/AdditionalKeys/fixture/composer.json
@@ -23,5 +23,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/AdditionalKeys/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/AdditionalKeys/fixture/composer.json
@@ -20,7 +20,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/Missing/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/Missing/fixture/composer.json
@@ -20,5 +20,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/Missing/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/Missing/fixture/composer.json
@@ -17,7 +17,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotGreaterThanZero/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotGreaterThanZero/fixture/composer.json
@@ -21,5 +21,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotGreaterThanZero/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotGreaterThanZero/fixture/composer.json
@@ -18,7 +18,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotInteger/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotInteger/fixture/composer.json
@@ -23,5 +23,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotInteger/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentSize/NotInteger/fixture/composer.json
@@ -20,7 +20,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/Missing/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/Missing/fixture/composer.json
@@ -20,5 +20,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/Missing/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/Missing/fixture/composer.json
@@ -17,7 +17,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotSpaceOrTab/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotSpaceOrTab/fixture/composer.json
@@ -21,5 +21,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotSpaceOrTab/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotSpaceOrTab/fixture/composer.json
@@ -18,7 +18,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotString/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotString/fixture/composer.json
@@ -23,5 +23,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotString/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/NotValid/IndentStyle/NotString/fixture/composer.json
@@ -20,7 +20,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/Valid/WithOptions/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/Valid/WithOptions/fixture/composer.json
@@ -21,5 +21,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/Valid/WithOptions/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/Valid/WithOptions/fixture/composer.json
@@ -18,7 +18,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/Valid/WithoutOptions/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/Valid/WithoutOptions/fixture/composer.json
@@ -21,5 +21,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Extra/Valid/WithoutOptions/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Extra/Valid/WithoutOptions/fixture/composer.json
@@ -18,7 +18,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/AlreadyNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/AlreadyNormalized/fixture/composer.json
@@ -21,5 +21,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/AlreadyNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/AlreadyNormalized/fixture/composer.json
@@ -18,7 +18,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/NotYetNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/NotYetNormalized/fixture/composer.json
@@ -15,5 +15,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/NotYetNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/NotYetNormalized/fixture/composer.json
@@ -12,7 +12,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/AlreadyNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/AlreadyNormalized/fixture/composer.json
@@ -21,5 +21,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/AlreadyNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/AlreadyNormalized/fixture/composer.json
@@ -18,7 +18,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/FreshAfter/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/FreshAfter/fixture/composer.json
@@ -16,5 +16,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/FreshAfter/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/FreshAfter/fixture/composer.json
@@ -13,7 +13,8 @@
   "_comment": "This composer.json is valid according to a lax validation, a composer.lock is present and fresh before invoking the command, composer.json is not yet normalized, and composer.lock is still fresh after invoking the command.",
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/NotFreshAfter/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/NotFreshAfter/fixture/composer.json
@@ -16,7 +16,8 @@
   "_comment": "This composer.json is valid according to a lax validation, a composer.lock is present and fresh before invoking the command, composer.json is not yet normalized, and composer.lock is not fresh after invoking the command.",
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/NotFreshAfter/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/NotYetNormalized/Lock/NotFreshAfter/fixture/composer.json
@@ -11,7 +11,12 @@
     "php": "^5.6"
   },
   "scripts": {
-    "hello": "echo 'Hello!'"
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   },
   "_comment": "This composer.json is valid according to a lax validation, a composer.lock is present and fresh before invoking the command, composer.json is not yet normalized, and composer.lock is not fresh after invoking the command.",
   "config": {

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/AlreadyNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/AlreadyNormalized/fixture/composer.json
@@ -21,5 +21,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/AlreadyNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/AlreadyNormalized/fixture/composer.json
@@ -18,7 +18,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/NotYetNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/NotYetNormalized/fixture/composer.json
@@ -21,5 +21,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/NotYetNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/NotYetNormalized/fixture/composer.json
@@ -18,7 +18,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithoutNoCheckLock/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithoutNoCheckLock/fixture/composer.json
@@ -21,5 +21,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithoutNoCheckLock/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithoutNoCheckLock/fixture/composer.json
@@ -18,7 +18,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Normalizer/Throws/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Normalizer/Throws/fixture/composer.json
@@ -15,5 +15,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Normalizer/Throws/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Normalizer/Throws/fixture/composer.json
@@ -12,7 +12,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Options/NotValid/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Options/NotValid/fixture/composer.json
@@ -15,5 +15,13 @@
       "ergebnis/composer-normalize": true,
       "ergebnis/*": false
     }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Options/NotValid/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Options/NotValid/fixture/composer.json
@@ -12,7 +12,8 @@
   },
   "config": {
     "allow-plugins": {
-      "ergebnis/composer-normalize": true
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
     }
   }
 }


### PR DESCRIPTION
This pull request

- [x] asserts that `config.allow-plugins` is not sorted
- [x] asserts that `scripts.auto-scripts` is not sorted
- [x] prevents updates of `ergebnis/json-normalizer` for now

Related to #704.
Related to #860.
Related to #868.