### PR TITLE
Enhancement: Require `ergebnis/json-normalizer:^4.0.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
     "ext-json": "*",
     "composer-plugin-api": "^2.0.0",
-    "ergebnis/json-normalizer": "~2.1.0",
+    "ergebnis/json-normalizer": "dev-main as 4.0.0",
     "ergebnis/json-printer": "^3.3.0",
     "justinrainbow/json-schema": "^5.2.12",
     "localheinz/diff": "^1.1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,39 +4,107 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c1e059a3fb260deff59c7bcdd06772a",
+    "content-hash": "20acf4cc54ac4015a0ce70aaf3c2a656",
     "packages": [
         {
-            "name": "ergebnis/json-normalizer",
-            "version": "2.1.0",
+            "name": "ergebnis/json",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/ergebnis/json-normalizer.git",
-                "reference": "2039eb11131a243b9204bf51219baa08935e6b1d"
+                "url": "https://github.com/ergebnis/json.git",
+                "reference": "d66ea30060856d0729a4aa319a02752519ca63a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/json-normalizer/zipball/2039eb11131a243b9204bf51219baa08935e6b1d",
-                "reference": "2039eb11131a243b9204bf51219baa08935e6b1d",
+                "url": "https://api.github.com/repos/ergebnis/json/zipball/d66ea30060856d0729a4aa319a02752519ca63a0",
+                "reference": "d66ea30060856d0729a4aa319a02752519ca63a0",
                 "shasum": ""
             },
             "require": {
-                "ergebnis/json-printer": "^3.2.0",
-                "ergebnis/json-schema-validator": "^2.0.0",
-                "ext-json": "*",
-                "justinrainbow/json-schema": "^5.2.11",
-                "php": "^7.4 || ^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
-                "ergebnis/data-provider": "^1.0.0",
-                "ergebnis/license": "^1.2.0",
-                "ergebnis/php-cs-fixer-config": "^3.4.0",
-                "fakerphp/faker": "^1.17.0",
-                "infection/infection": "~0.25.5",
-                "phpunit/phpunit": "^9.5.11",
-                "psalm/plugin-phpunit": "~0.16.1",
-                "vimeo/psalm": "^4.17.0"
+                "ergebnis/composer-normalize": "^2.29.0",
+                "ergebnis/data-provider": "^1.2.0",
+                "ergebnis/license": "^2.1.0",
+                "ergebnis/php-cs-fixer-config": "^5.0.0",
+                "ergebnis/phpstan-rules": "^1.0.0",
+                "fakerphp/faker": "^1.20.0",
+                "infection/infection": "~0.26.16",
+                "phpunit/phpunit": "^9.5.27",
+                "psalm/plugin-phpunit": "~0.18.4",
+                "vimeo/psalm": "^5.1.0"
             },
+            "type": "library",
+            "extra": {
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Json\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides a Json value object for representing a valid JSON string.",
+            "homepage": "https://github.com/ergebnis/json",
+            "keywords": [
+                "json"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/json/issues",
+                "source": "https://github.com/ergebnis/json"
+            },
+            "time": "2022-12-10T22:38:50+00:00"
+        },
+        {
+            "name": "ergebnis/json-normalizer",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/json-normalizer.git",
+                "reference": "c624fb18a8f03cf67b885565a75ad641e46a9f7d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/json-normalizer/zipball/c624fb18a8f03cf67b885565a75ad641e46a9f7d",
+                "reference": "c624fb18a8f03cf67b885565a75ad641e46a9f7d",
+                "shasum": ""
+            },
+            "require": {
+                "ergebnis/json": "^1.0.1",
+                "ergebnis/json-pointer": "^3.2.0",
+                "ergebnis/json-printer": "^3.3.0",
+                "ergebnis/json-schema-validator": "^4.0.0",
+                "ext-json": "*",
+                "justinrainbow/json-schema": "^5.2.12",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+            },
+            "require-dev": {
+                "ergebnis/data-provider": "^1.3.0",
+                "ergebnis/license": "^2.1.0",
+                "ergebnis/php-cs-fixer-config": "^5.1.1",
+                "fakerphp/faker": "^1.21.0",
+                "infection/infection": "~0.26.16",
+                "phpunit/phpunit": "^9.5.27",
+                "psalm/plugin-phpunit": "~0.18.4",
+                "rector/rector": "~0.15.2",
+                "symfony/filesystem": "^5.0.0 || ^6.0.0",
+                "symfony/finder": "^5.0.0 || ^6.0.0",
+                "vimeo/psalm": "^5.4.0"
+            },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -63,13 +131,70 @@
                 "issues": "https://github.com/ergebnis/json-normalizer/issues",
                 "source": "https://github.com/ergebnis/json-normalizer"
             },
-            "funding": [
+            "time": "2023-01-03T17:10:27+00:00"
+        },
+        {
+            "name": "ergebnis/json-pointer",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/json-pointer.git",
+                "reference": "861516ff5afa1aa8905fdf3361315909523a1bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/json-pointer/zipball/861516ff5afa1aa8905fdf3361315909523a1bf8",
+                "reference": "861516ff5afa1aa8905fdf3361315909523a1bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.28.3",
+                "ergebnis/data-provider": "^1.2.0",
+                "ergebnis/license": "^2.1.0",
+                "ergebnis/php-cs-fixer-config": "^5.0.0",
+                "fakerphp/faker": "^1.20.0",
+                "infection/infection": "~0.26.16",
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "~0.18.3",
+                "vimeo/psalm": "^4.30"
+            },
+            "type": "library",
+            "extra": {
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Json\\Pointer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
                 {
-                    "url": "https://github.com/localheinz",
-                    "type": "github"
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
                 }
             ],
-            "time": "2022-01-04T11:19:55+00:00"
+            "description": "Provides JSON pointer as a value object.",
+            "homepage": "https://github.com/ergebnis/json-pointer",
+            "keywords": [
+                "RFC6901",
+                "json",
+                "pointer"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/json-pointer/issues",
+                "source": "https://github.com/ergebnis/json-pointer"
+            },
+            "time": "2022-11-28T17:03:31+00:00"
         },
         {
             "name": "ergebnis/json-printer",
@@ -130,33 +255,35 @@
         },
         {
             "name": "ergebnis/json-schema-validator",
-            "version": "2.0.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ergebnis/json-schema-validator.git",
-                "reference": "dacd8a47c1cc2c426ec71e952da3609ebe901fac"
+                "reference": "a6166272ac5691a9bc791f185841e5f92a6d4723"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/json-schema-validator/zipball/dacd8a47c1cc2c426ec71e952da3609ebe901fac",
-                "reference": "dacd8a47c1cc2c426ec71e952da3609ebe901fac",
+                "url": "https://api.github.com/repos/ergebnis/json-schema-validator/zipball/a6166272ac5691a9bc791f185841e5f92a6d4723",
+                "reference": "a6166272ac5691a9bc791f185841e5f92a6d4723",
                 "shasum": ""
             },
             "require": {
+                "ergebnis/json": "^1.0.0",
+                "ergebnis/json-pointer": "^3.2.0",
                 "ext-json": "*",
-                "justinrainbow/json-schema": "^5.2.10",
-                "php": "^7.4 || ^8.0"
+                "justinrainbow/json-schema": "^5.2.12",
+                "php": "^8.0"
             },
             "require-dev": {
-                "ergebnis/composer-normalize": "^2.18.0",
-                "ergebnis/data-provider": "^1.0.0",
-                "ergebnis/license": "^1.1.0",
-                "ergebnis/php-cs-fixer-config": "~3.4.0",
-                "fakerphp/faker": "^1.17.0",
-                "infection/infection": "~0.25.3",
-                "phpunit/phpunit": "~9.5.10",
-                "psalm/plugin-phpunit": "~0.16.1",
-                "vimeo/psalm": "^4.15.0"
+                "ergebnis/composer-normalize": "^2.21.0",
+                "ergebnis/data-provider": "^1.2.0",
+                "ergebnis/license": "^2.1.0",
+                "ergebnis/php-cs-fixer-config": "~5.0.0",
+                "fakerphp/faker": "^1.20.0",
+                "infection/infection": "~0.26.16",
+                "phpunit/phpunit": "~9.5.27",
+                "psalm/plugin-phpunit": "~0.18.4",
+                "vimeo/psalm": "^5.1.0"
             },
             "type": "library",
             "extra": {
@@ -191,13 +318,7 @@
                 "issues": "https://github.com/ergebnis/json-schema-validator/issues",
                 "source": "https://github.com/ergebnis/json-schema-validator"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/localheinz",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-12-13T16:54:56+00:00"
+            "time": "2022-12-10T14:50:15+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -6779,9 +6900,18 @@
             "time": "2022-06-03T18:03:27+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "ergebnis/json-normalizer",
+            "version": "dev-main",
+            "alias": "4.0.0",
+            "alias_normalized": "4.0.0.0"
+        }
+    ],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "ergebnis/json-normalizer": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -20,6 +20,7 @@ use Composer\Factory;
 use Composer\IO;
 use Ergebnis\Composer\Normalize\Exception;
 use Ergebnis\Composer\Normalize\Version;
+use Ergebnis\Json\Json;
 use Ergebnis\Json\Normalizer;
 use Ergebnis\Json\Printer;
 use Localheinz\Diff;
@@ -32,7 +33,7 @@ final class NormalizeCommand extends Command\BaseCommand
 {
     public function __construct(
         private Factory $factory,
-        private Normalizer\NormalizerInterface $normalizer,
+        private Normalizer\Normalizer $normalizer,
         private Printer\PrinterInterface $printer,
         private Diff\Differ $differ,
     ) {
@@ -185,48 +186,24 @@ final class NormalizeCommand extends Command\BaseCommand
         /** @var string $encoded */
         $encoded = \file_get_contents($composerFile);
 
-        $json = Normalizer\Json::fromEncoded($encoded);
+        $json = Json::fromString($encoded);
 
-        $format = Normalizer\Format\Format::fromJson($json);
-
-        if (null !== $indent) {
-            $format = $format->withIndent($indent);
+        if (null === $indent) {
+            $indent = Normalizer\Format\Format::fromJson($json)->indent();
         }
 
         $normalizer = new Normalizer\ChainNormalizer(
             $this->normalizer,
-            new class($this->printer, $format) implements Normalizer\NormalizerInterface {
-                public function __construct(
-                    private Printer\PrinterInterface $printer,
-                    private Normalizer\Format\Format $format,
-                ) {
-                }
-
-                public function normalize(Normalizer\Json $json): Normalizer\Json
-                {
-                    $encoded = \json_encode(
-                        $json->decoded(),
-                        $this->format->jsonEncodeOptions()->toInt(),
-                    );
-
-                    $printed = $this->printer->print(
-                        $encoded,
-                        $this->format->indent()->toString(),
-                        $this->format->newLine()->toString(),
-                    );
-
-                    if (!$this->format->hasFinalNewLine()) {
-                        return Normalizer\Json::fromEncoded($printed);
-                    }
-
-                    return Normalizer\Json::fromEncoded($printed . $this->format->newLine()->toString());
-                }
-            },
+            new Normalizer\IndentNormalizer(
+                $indent,
+                $this->printer,
+            ),
+            new Normalizer\WithFinalNewLineNormalizer(),
         );
 
         try {
             $normalized = $normalizer->normalize($json);
-        } catch (Normalizer\Exception\OriginalInvalidAccordingToSchemaException $exception) {
+        } catch (Normalizer\Exception\OriginalInvalidAccordingToSchema $exception) {
             $io->writeError('<error>Original composer.json does not match the expected JSON schema:</error>');
 
             self::showValidationErrors(
@@ -235,7 +212,7 @@ final class NormalizeCommand extends Command\BaseCommand
             );
 
             return 1;
-        } catch (Normalizer\Exception\NormalizedInvalidAccordingToSchemaException $exception) {
+        } catch (Normalizer\Exception\NormalizedInvalidAccordingToSchema $exception) {
             $io->writeError('<error>Normalized composer.json does not match the expected JSON schema:</error>');
 
             self::showValidationErrors(

--- a/test/Integration/Command/NormalizeCommand/Normalizer/Throws/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Normalizer/Throws/Test.php
@@ -17,6 +17,7 @@ use Composer\Factory;
 use Ergebnis\Composer\Normalize\Command\NormalizeCommand;
 use Ergebnis\Composer\Normalize\Test\Integration;
 use Ergebnis\Composer\Normalize\Test\Util;
+use Ergebnis\Json\Json;
 use Ergebnis\Json\Normalizer;
 use Ergebnis\Json\Printer;
 use Localheinz\Diff;
@@ -51,12 +52,12 @@ final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
 
         $application = self::createApplication(new NormalizeCommand(
             new Factory(),
-            new class($exceptionMessage) implements Normalizer\NormalizerInterface {
+            new class($exceptionMessage) implements Normalizer\Normalizer {
                 public function __construct(private string $exceptionMessage)
                 {
                 }
 
-                public function normalize(Normalizer\Json $json): Normalizer\Json
+                public function normalize(Json $json): Json
                 {
                     throw new \RuntimeException($this->exceptionMessage);
                 }


### PR DESCRIPTION
This pull request

- [x] requires `ergebnis/json-normalizer:dev-main as 4.0.0`
- [x] adjusts class names

Related to #868.