### PR TITLE
Fix test cases for new normalisation rules

### DIFF
--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/AlreadyNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/NotPresent/Json/AlreadyNormalized/fixture/composer.json
@@ -24,10 +24,10 @@
   },
   "scripts": {
     "auto-scripts": {
-      "cache:clear": "symfony-cmd",
-      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd",
       "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
-      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd"
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/AlreadyNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/FreshBefore/Json/AlreadyNormalized/fixture/composer.json
@@ -24,10 +24,10 @@
   },
   "scripts": {
     "auto-scripts": {
-      "cache:clear": "symfony-cmd",
-      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd",
       "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
-      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd"
     }
   }
 }

--- a/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/AlreadyNormalized/fixture/composer.json
+++ b/test/Integration/Command/NormalizeCommand/Json/Valid/Lock/Present/NotFreshBefore/WithNoCheckLock/Json/AlreadyNormalized/fixture/composer.json
@@ -24,10 +24,10 @@
   },
   "scripts": {
     "auto-scripts": {
-      "cache:clear": "symfony-cmd",
-      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd",
       "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
-      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+      "cache:clear": "symfony-cmd",
+      "doctrine:migrations:migrate -v": "symfony-cmd"
     }
   }
 }


### PR DESCRIPTION
These test cases claim to be "already normalized". According to the rules in version 2.x of `ergebnis/json-normalizer` they are normalised and all is well. However, according to the rules in version 3.x of `ergebnis/json-normalizer`, they are not yet normalised. Changing them now makes no difference to the test-suite, however, with the files as they are, the test suite fails on #956; after this pull request has been merged, the test suite in #956 will pass, which should allow that to be merged in.

Related to #956 and #868.