### PR TITLE
Fix: Use `Printer` instead of `Formatter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.28.3...main`][2.29.0...main].
 
+### Changed
+
+- Started injecting `Printer\Printer` instead of `Formatter\Formatter` into `NormalizeCommand` ([#1008]), by [@ergebnis-bot]
+
 ## [`2.29.0`][2.29.0]
 
 For a full diff see [`2.28.3...2.29.0`][2.28.3...2.29.0].
@@ -993,6 +997,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#959]: https://github.com/ergebnis/composer-normalize/pull/959
 [#998]: https://github.com/ergebnis/composer-normalize/pull/998
 [#1004]: https://github.com/ergebnis/composer-normalize/pull/1004
+[#1008]: https://github.com/ergebnis/composer-normalize/pull/1008
 
 [@core23]: https://github.com/core23
 [@dependabot]: https://github.com/dependabot

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
   },
   "require": {
     "php": "^8.0",
+    "ext-json": "*",
     "composer-plugin-api": "^2.0.0",
     "ergebnis/json-normalizer": "~2.1.0",
     "ergebnis/json-printer": "^3.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4738167eb0913c1517506646dbeefc0f",
+    "content-hash": "468f03325f9dbb6f51bdcddc5ca21928",
     "packages": [
         {
             "name": "ergebnis/json-normalizer",
@@ -5811,6 +5811,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^8.0",
+        "ext-json": "*",
         "composer-plugin-api": "^2.0.0"
     },
     "platform-dev": [],

--- a/phar/composer-normalize.php
+++ b/phar/composer-normalize.php
@@ -24,7 +24,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 $command = new Normalize\Command\NormalizeCommand(
     new Factory(),
     new Normalizer\Vendor\Composer\ComposerJsonNormalizer(__DIR__ . '/../resource/schema.json'),
-    new Normalizer\Format\Formatter(new Printer\Printer()),
+    new Printer\Printer(),
     new Diff\Differ(new Diff\Output\StrictUnifiedDiffOutputBuilder([
         'fromFile' => 'original',
         'toFile' => 'normalized',

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -21,6 +21,7 @@ use Composer\IO;
 use Ergebnis\Composer\Normalize\Exception;
 use Ergebnis\Composer\Normalize\Version;
 use Ergebnis\Json\Normalizer;
+use Ergebnis\Json\Printer;
 use Localheinz\Diff;
 use Symfony\Component\Console;
 
@@ -32,7 +33,7 @@ final class NormalizeCommand extends Command\BaseCommand
     public function __construct(
         private Factory $factory,
         private Normalizer\NormalizerInterface $normalizer,
-        private Normalizer\Format\FormatterInterface $formatter,
+        private Printer\PrinterInterface $printer,
         private Diff\Differ $differ,
     ) {
         parent::__construct('normalize');
@@ -186,8 +187,45 @@ final class NormalizeCommand extends Command\BaseCommand
 
         $json = Normalizer\Json::fromEncoded($encoded);
 
+        $format = Normalizer\Format\Format::fromJson($json);
+
+        if (null !== $indent) {
+            $format = $format->withIndent($indent);
+        }
+
+        $normalizer = new Normalizer\ChainNormalizer(
+            $this->normalizer,
+            new class($this->printer, $format) implements Normalizer\NormalizerInterface {
+                public function __construct(
+                    private Printer\PrinterInterface $printer,
+                    private Normalizer\Format\Format $format,
+                ) {
+                }
+
+                public function normalize(Normalizer\Json $json): Normalizer\Json
+                {
+                    $encoded = \json_encode(
+                        $json->decoded(),
+                        $this->format->jsonEncodeOptions()->toInt(),
+                    );
+
+                    $printed = $this->printer->print(
+                        $encoded,
+                        $this->format->indent()->toString(),
+                        $this->format->newLine()->toString(),
+                    );
+
+                    if (!$this->format->hasFinalNewLine()) {
+                        return Normalizer\Json::fromEncoded($printed);
+                    }
+
+                    return Normalizer\Json::fromEncoded($printed . $this->format->newLine()->toString());
+                }
+            },
+        );
+
         try {
-            $normalized = $this->normalizer->normalize($json);
+            $normalized = $normalizer->normalize($json);
         } catch (Normalizer\Exception\OriginalInvalidAccordingToSchemaException $exception) {
             $io->writeError('<error>Original composer.json does not match the expected JSON schema:</error>');
 
@@ -215,18 +253,7 @@ final class NormalizeCommand extends Command\BaseCommand
             return 1;
         }
 
-        $format = Normalizer\Format\Format::fromJson($json);
-
-        if (null !== $indent) {
-            $format = $format->withIndent($indent);
-        }
-
-        $formatted = $this->formatter->format(
-            $normalized,
-            $format,
-        );
-
-        if ($json->encoded() === $formatted->encoded()) {
+        if ($json->encoded() === $normalized->encoded()) {
             $io->write(\sprintf(
                 '<info>%s is already normalized.</info>',
                 $composerFile,
@@ -246,7 +273,7 @@ final class NormalizeCommand extends Command\BaseCommand
 
             $diff = $this->differ->diff(
                 $json->encoded(),
-                $formatted->encoded(),
+                $normalized->encoded(),
             );
 
             $io->write([
@@ -264,7 +291,7 @@ final class NormalizeCommand extends Command\BaseCommand
 
         \file_put_contents(
             $composerFile,
-            $formatted->encoded(),
+            $normalized->encoded(),
         );
 
         $io->write(\sprintf(

--- a/src/NormalizePlugin.php
+++ b/src/NormalizePlugin.php
@@ -60,7 +60,7 @@ final class NormalizePlugin implements
                     'file://%s',
                     \realpath(__DIR__ . '/../resource/schema.json'),
                 )),
-                new Normalizer\Format\Formatter(new Printer\Printer()),
+                new Printer\Printer(),
                 new Diff\Differ(new Diff\Output\StrictUnifiedDiffOutputBuilder([
                     'fromFile' => 'original',
                     'toFile' => 'normalized',

--- a/test/Integration/Command/NormalizeCommand/Normalizer/Throws/Test.php
+++ b/test/Integration/Command/NormalizeCommand/Normalizer/Throws/Test.php
@@ -61,7 +61,7 @@ final class Test extends Integration\Command\NormalizeCommand\AbstractTestCase
                     throw new \RuntimeException($this->exceptionMessage);
                 }
             },
-            new Normalizer\Format\Formatter(new Printer\Printer()),
+            new Printer\Printer(),
             new Diff\Differ(new Diff\Output\StrictUnifiedDiffOutputBuilder([
                 'fromFile' => 'original',
                 'toFile' => 'normalized',


### PR DESCRIPTION
This pull request

- [x] uses the `Printer` instead of `Formatter` in `NormalizeCommand`