### PR TITLE
Fix: Use `~` operator to limit compatibility with PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "source": "https://github.com/ergebnis/composer-normalize"
   },
   "require": {
-    "php": "^8.0",
+    "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
     "ext-json": "*",
     "composer-plugin-api": "^2.0.0",
     "ergebnis/json-normalizer": "~2.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "468f03325f9dbb6f51bdcddc5ca21928",
+    "content-hash": "46111aae55cbae618252012a5968cd40",
     "packages": [
         {
             "name": "ergebnis/json-normalizer",
@@ -5810,7 +5810,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-json": "*",
         "composer-plugin-api": "^2.0.0"
     },


### PR DESCRIPTION
This pull request

- [x] uses the `~` operator to limit the compatibility with PHP versions 

Follows https://github.com/ergebnis/php-package-template/pull/1086.