### PR TITLE
Respect `--no-plugins` and `--no-scripts` option value follow up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For a full diff see [`2.37.0...main`][2.37.0...main].
 
 ### Fixed
 
+- Adjusted `Command\NormalizeCommand` to respect `--no-ansi`, `--no-plugins`, `--no-scripts` options ([#1184]), by [@mxr576]
 - Updated `composer/composer` ([#1188]), by [@localheinz]
 
 ## [`2.37.0`][2.37.0]

--- a/src/Command/NormalizeCommand.php
+++ b/src/Command/NormalizeCommand.php
@@ -523,15 +523,19 @@ final class NormalizeCommand extends Command\BaseCommand
             '--ignore-platform-reqs' => true,
             '--lock' => true,
             '--no-autoloader' => true,
-            '--no-plugins' => $input->getOption('no-plugins'),
-            '--no-scripts' => $input->getOption('no-scripts'),
             '--working-dir' => $workingDirectory,
         ];
 
         if ($input->hasParameterOption('--no-ansi')) {
-            $parameters = \array_merge($parameters, [
-                '--no-ansi' => true,
-            ]);
+            $parameters[] = '--no-ansi';
+        }
+
+        if ($input->hasParameterOption('--no-plugins')) {
+            $parameters[] = '--no-plugins';
+        }
+
+        if ($input->hasParameterOption('--no-scripts')) {
+            $parameters[] = '--no-scripts';
         }
 
         return $application->run(


### PR DESCRIPTION
This pull request if a follow up on #1141 where it seems I have made a mistake :man_facepalming:  I did not realize that these are option flags therefore their value does not matter... I have just 'blindly" adjusted the original code, run some tests and it seems the fix is working... well, it does not because Composer internally [only checks whether these flags are set or not](https://github.com/composer/composer/blob/2.6.5/src/Composer/Command/BaseCommand.php#L224-L225) and not their value.

Follows #1141.
Fixes #1130.
