### PR TITLE
Fix: Do not configure `platform`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,9 +65,6 @@
     "audit": {
       "abandoned": "report"
     },
-    "platform": {
-      "php": "8.1.20"
-    },
     "preferred-install": "dist",
     "sort-packages": true
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c0c518182601701662e02a3fa9ed59a",
+    "content-hash": "8b93ffb39dd8788002b19ea19994bd7e",
     "packages": [
         {
             "name": "ergebnis/json",
@@ -6871,8 +6871,5 @@
         "composer-plugin-api": "^2.0.0"
     },
     "platform-dev": [],
-    "platform-overrides": {
-        "php": "8.1.20"
-    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This pull request

- [x] stops configuring the [`platform`](https://getcomposer.org/doc/06-config.md#platform) in `composer.json`

Follows https://github.com/ergebnis/php-package-template/pull/1376.