### PR TITLE
Fix: Prevent installation of `symfony/console:^7.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For a full diff see [`2.39.0...main`][2.39.0...main].
 
 - Updated `schema.json` ([#1204]), by [@ergebnis-bot]
 
+### Fixed
+
+- Prevented installation of `symfony/console:^7.0.0` ([#1234]), by [@localheinz]
+
 ## [`2.39.0`][2.39.0]
 
 For a full diff see [`2.38.0...2.39.0`][2.38.0...2.39.0].
@@ -1165,6 +1169,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#1192]: https://github.com/ergebnis/composer-normalize/pull/1192
 [#1195]: https://github.com/ergebnis/composer-normalize/pull/1195
 [#1204]: https://github.com/ergebnis/composer-normalize/pull/1204
+[#1234]: https://github.com/ergebnis/composer-normalize/pull/1234
 
 [@core23]: https://github.com/core23
 [@dependabot]: https://github.com/dependabot

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,9 @@
     "symfony/filesystem": "^6.4.0",
     "vimeo/psalm": "^5.17.0"
   },
+  "conflict": {
+    "symfony/console": "^7.0.0"
+  },
   "minimum-stability": "dev",
   "prefer-stable": true,
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e270b25defdceb0b2455f84fa92e305a",
+    "content-hash": "d381cb915071c5709f7fca4495b19ff7",
     "packages": [
         {
             "name": "ergebnis/json",


### PR DESCRIPTION
This pull request

- [x] prevents installation of `symfony/console:^7.0.0`

Related to #1233.