### PR TITLE
add "dev" keyword to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "type": "composer-plugin",
   "keywords": [
+    "dev",
     "composer",
     "normalizer",
     "normalize",


### PR DESCRIPTION
This pull request

- [x] make composer suggest to install this package as dev dependency (with --dev flag)

[See composer doc](https://getcomposer.org/doc/04-schema.md#keywords)