### PR TITLE
[#1481] Added PHP 8.5 to CI.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -40,6 +40,9 @@ branches:
           - context: "Tests (8.4, highest)"
           - context: "Tests (8.4, locked)"
           - context: "Tests (8.4, lowest)"
+          - context: "Tests (8.5, highest)"
+          - context: "Tests (8.5, locked)"
+          - context: "Tests (8.5, lowest)"
         strict: false
       restrictions:
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -517,6 +517,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
 
         dependencies:
           - "lowest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`2.47.0...main`][2.47.0...main].
 
 - Updated `schema.json` ([#1454]), by [@ergebnis-bot]
 - Allowed installation on PHP 8.5 ([#1485]), by [@localheinz]
+- Added support for PHP 8.5 ([#1490]), by [@AlexSkrypnyk]
 - Updated `localheinz/diff` ([#1493]), by [@andrey-helldar]
 
 ## [`2.47.0`][2.47.0]
@@ -1303,8 +1304,10 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#1441]: https://github.com/ergebnis/composer-normalize/pull/1441
 [#1454]: https://github.com/ergebnis/composer-normalize/pull/1454
 [#1485]: https://github.com/ergebnis/composer-normalize/pull/1485
+[#1490]: https://github.com/ergebnis/composer-normalize/pull/1490
 [#1493]: https://github.com/ergebnis/composer-normalize/pull/1493
 
+[@AlexSkrypnyk]: https://github.com/AlexSkrypnyk
 [@andrey-helldar]: https://github.com/andrey-helldar
 [@core23]: https://github.com/core23
 [@dependabot]: https://github.com/dependabot


### PR DESCRIPTION
This pull request

- Added PHP 8.5 to CI.

Followed similar commit when PHP 8.4 support was added https://github.com/ergebnis/composer-normalize/commit/3148f21fc65b96de08df9acb82baf3ef76e6871c#diff-d684acc09c646fd347d0ee93598101fb403664cc70e38cb6f671355ab6de1854

Fixes #1481.
