### PR TITLE
[Fix] `localheinz/diff` dependency to version 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`2.47.0...main`][2.47.0...main].
 
 - Updated `schema.json` ([#1454]), by [@ergebnis-bot]
 - Allowed installation on PHP 8.5 ([#1485]), by [@localheinz]
+- Updated `localheinz/diff` ([#1493]), by [@andrey-helldar]
 
 ## [`2.47.0`][2.47.0]
 
@@ -1302,7 +1303,9 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#1441]: https://github.com/ergebnis/composer-normalize/pull/1441
 [#1454]: https://github.com/ergebnis/composer-normalize/pull/1454
 [#1485]: https://github.com/ergebnis/composer-normalize/pull/1485
+[#1493]: https://github.com/ergebnis/composer-normalize/pull/1493
 
+[@andrey-helldar]: https://github.com/andrey-helldar
 [@core23]: https://github.com/core23
 [@dependabot]: https://github.com/dependabot
 [@ergebnis-bot]: https://github.com/ergebnis-bot

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "ergebnis/json-normalizer": "^4.9.0",
     "ergebnis/json-printer": "^3.7.0",
     "justinrainbow/json-schema": "^5.2.12 || ^6.0.0",
-    "localheinz/diff": "^1.2.0"
+    "localheinz/diff": "^1.3.0"
   },
   "require-dev": {
     "composer/composer": "^2.8.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c33e2772fb3c0ca0038f0b49d67ce24e",
+    "content-hash": "6c91499a10773674057e490037fd842f",
     "packages": [
         {
             "name": "ergebnis/json",
@@ -438,20 +438,20 @@
         },
         {
             "name": "localheinz/diff",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localheinz/diff.git",
-                "reference": "ec413943c2b518464865673fd5b38f7df867a010"
+                "reference": "33bd840935970cda6691c23fc7d94ae764c0734c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/diff/zipball/ec413943c2b518464865673fd5b38f7df867a010",
-                "reference": "ec413943c2b518464865673fd5b38f7df867a010",
+                "url": "https://api.github.com/repos/localheinz/diff/zipball/33bd840935970cda6691c23fc7d94ae764c0734c",
+                "reference": "33bd840935970cda6691c23fc7d94ae764c0734c",
                 "shasum": ""
             },
             "require": {
-                "php": "~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+                "php": "~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.5.0 || ^8.5.23",
@@ -487,9 +487,9 @@
             ],
             "support": {
                 "issues": "https://github.com/localheinz/diff/issues",
-                "source": "https://github.com/localheinz/diff/tree/1.2.0"
+                "source": "https://github.com/localheinz/diff/tree/1.3.0"
             },
-            "time": "2024-12-04T14:16:01+00:00"
+            "time": "2025-08-30T09:44:18+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Description

Today I discovered a problem - the normalizer stopped starting.

The reason is the updated dependency `localheinz/diff` to version 1.4.1.

Apparently, someone [pushed](https://packagist.org/packages/localheinz/diff#1.4.1) the old tags:

<img width="130" height="148" alt="image" src="https://github.com/user-attachments/assets/172748bc-30e1-4956-8ca6-70564d099a4a" />

Release dates for tags:

- 1.3.0 - 2025-08-30 09:44 UTC
- 1.4.0 - 2015-12-06 07:21 UTC
- 1.4.1 - 2015-12-08 07:14 UTC
- 1.4.2 - 2017-05-18 13:44 UTC
- 1.4.3 - 2017-05-22 07:24 UTC

Why `1.4.1` version? It's simple:

- 1.4.1 requires PHP `>=5.3.3`
- 1.4.2 requires PHP `^5.3.3 || ^7.0`
- 1.4.3 requires PHP `^5.3.3 || ^7.0`

I use a PHP 8.3 and 8.4 versions.

## Reproducing the problem:

```bash
$ composer global update
...
  - Downloading localheinz/diff (1.4.1): Extracting archive
  - Installing localheinz/diff (1.4.1): Extracting archive
```
```bash
$ composer normalize
PHP Fatal error:  Uncaught Error: Class "Localheinz\Diff\Differ" not found in C:\Users\Helldar\AppData\Roaming\Composer\vendor\ergebnis\composer-normalize\src\NormalizePlugin.php:64
Stack trace:
#0 phar://C:/ProgramData/ComposerSetup/bin/composer.phar/src/Composer/Console/Application.php(710): Ergebnis\Composer\Normalize\NormalizePlugin->getCommands()
#1 phar://C:/ProgramData/ComposerSetup/bin/composer.phar/src/Composer/Console/Application.php(279): Composer\Console\Application->getPluginCommands()
#2 phar://C:/ProgramData/ComposerSetup/bin/composer.phar/vendor/symfony/console/Application.php(171): Composer\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 phar://C:/ProgramData/ComposerSetup/bin/composer.phar/src/Composer/Console/Application.php(137): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 phar://C:/ProgramData/ComposerSetup/bin/composer.phar/bin/composer(98): Composer\Console\Application->run()
#5 C:\ProgramData\ComposerSetup\bin\composer.phar(29): require('phar://C:/Progr...')
#6 {main}
  thrown in C:\Users\Helldar\AppData\Roaming\Composer\vendor\ergebnis\composer-normalize\src\NormalizePlugin.php on line 64
```

## Environment

- PHP 8.3, 8.4
- OS Windows 11

## Hotfix for developers

```bash
# for global usage
composer global require localheinz/diff:1.3.0

# for local usage
composer require localheinz/diff:1.3.0 --dev
```
Fix is working:
```bash
$ composer normalize                          
Running ergebnis/composer-normalize by Andreas Möller and contributors.

./composer.json is already normalized.
```