### PR TITLE
Fix: Create release in draft mode, upload assets, and then publish release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,8 +99,9 @@ jobs:
         run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
 
       - name: "Create release"
-        uses: "ergebnis/.github/actions/github/release/create@1.9.3"
+        uses: "ergebnis/.github/actions/github/release/create@1.10.0"
         with:
+          draft: "true"
           github-token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
 
       - name: "Upload release assets"
@@ -135,6 +136,12 @@ jobs:
                 core.setFailed(error.message);
               }
             }
+
+      - name: "Publish release"
+        uses: "ergebnis/.github/actions/github/release/publish@1.10.0"
+        with:
+          github-token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
+          release-id: "${{ env.RELEASE_ID }}"
 
       - name: "Post to twitter.com about release"
         uses: "Eomm/why-don-t-you-tweet@v2.0.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.48.0...main`][2.48.0...main].
 
+### Fixed
+
+- Adjusted release workflow to create a release in draft mode, upload release assets, and then publish the release ([#1496]), by [@localheinz]
+
 ## [`2.48.0`][2.48.0]
 
 For a full diff see [`2.47.0...2.48.0`][2.47.0...2.48.0].
@@ -1312,6 +1316,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#1485]: https://github.com/ergebnis/composer-normalize/pull/1485
 [#1490]: https://github.com/ergebnis/composer-normalize/pull/1490
 [#1493]: https://github.com/ergebnis/composer-normalize/pull/1493
+[#1496]: https://github.com/ergebnis/composer-normalize/pull/1496
 
 [@AlexSkrypnyk]: https://github.com/AlexSkrypnyk
 [@andrey-helldar]: https://github.com/andrey-helldar


### PR DESCRIPTION
This pull request

- [x] adjusts the release workflow to create a release in draft mode, upload release assets, and then publish the release

Fixes #1495.