### PR TITLE
Fix: Resolve version from `composer` runtime when installed as `composer` plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ For a full diff see [`2.52.0...main`][2.52.0...main].
 - Updated `schema.json` ([#1623]), by [@ergebnis-bot]
 - Updated `composer/composer` ([#1672]), by [@localheinz]
 
+### Fixed
+
+- Adjusted `Version` to resolve the version from the `composer` runtime when installed as a `composer` plugin ([#1685]), by [@localheinz]
+
 ## [`2.52.0`][2.52.0]
 
 For a full diff see [`2.51.0...2.52.0`][2.51.0...2.52.0].
@@ -1391,6 +1395,7 @@ For a full diff see [`81bc3a8...0.1.0`][81bc3a8...0.1.0].
 [#1616]: https://github.com/ergebnis/composer-normalize/pull/1616
 [#1623]: https://github.com/ergebnis/composer-normalize/pull/1623
 [#1672]: https://github.com/ergebnis/composer-normalize/pull/1672
+[#1685]: https://github.com/ergebnis/composer-normalize/pull/1685
 
 [@AlexSkrypnyk]: https://github.com/AlexSkrypnyk
 [@andrey-helldar]: https://github.com/andrey-helldar

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
     "ext-json": "*",
     "composer-plugin-api": "^2.0.0",
+    "composer-runtime-api": "^2.0.0",
     "ergebnis/json": "^1.4.0",
     "ergebnis/json-normalizer": "^4.9.0",
     "ergebnis/json-printer": "^3.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8350457d163b4284617ca99560d14195",
+    "content-hash": "7a38c178ecf7b520696fb1d8b93645a2",
     "packages": [
         {
             "name": "ergebnis/json",
@@ -6555,7 +6555,8 @@
     "platform": {
         "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "ext-json": "*",
-        "composer-plugin-api": "^2.0.0"
+        "composer-plugin-api": "^2.0.0",
+        "composer-runtime-api": "^2.0.0"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/src/Version.php
+++ b/src/Version.php
@@ -13,11 +13,16 @@ declare(strict_types=1);
 
 namespace Ergebnis\Composer\Normalize;
 
+use Composer\InstalledVersions;
+
 /**
  * @internal
  */
 final class Version
 {
+    private const NAME = 'ergebnis/composer-normalize';
+    private const ATTRIBUTION = 'by <info>Andreas Möller</info> and contributors';
+
     /**
      * @see https://github.com/box-project/box/blob/master/doc/configuration.md#pretty-git-tag-placeholder-git
      */
@@ -25,24 +30,40 @@ final class Version
 
     public static function long(): string
     {
-        $name = 'ergebnis/composer-normalize';
-        $attribution = 'by <info>Andreas Möller</info> and contributors';
+        $version = self::version();
 
-        $version = self::$version;
-
-        if ('@' . 'git@' === $version) {
+        if ('' === $version) {
             return \sprintf(
                 '<info>%s</info> %s',
-                $name,
-                $attribution,
+                self::NAME,
+                self::ATTRIBUTION,
             );
         }
 
         return \sprintf(
             '<info>%s</info> %s %s',
-            $name,
+            self::NAME,
             $version,
-            $attribution,
+            self::ATTRIBUTION,
         );
+    }
+
+    private static function version(): string
+    {
+        if ('@' . 'git@' !== self::$version) {
+            return self::$version;
+        }
+
+        if (!InstalledVersions::isInstalled(self::NAME)) {
+            return '';
+        }
+
+        $version = InstalledVersions::getPrettyVersion(self::NAME);
+
+        if (!\is_string($version)) {
+            return '';
+        }
+
+        return $version;
     }
 }

--- a/test/Unit/VersionTest.php
+++ b/test/Unit/VersionTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Ergebnis\Composer\Normalize\Test\Unit;
 
+use Composer\InstalledVersions;
+use Ergebnis\Composer\Normalize\Test;
 use Ergebnis\Composer\Normalize\Version;
 use PHPUnit\Framework;
 
@@ -21,10 +23,57 @@ use PHPUnit\Framework;
  */
 final class VersionTest extends Framework\TestCase
 {
-    public function testLongReturnsVersion(): void
+    use Test\Util\Helper;
+
+    public function testLongReturnsVersionWhenPlaceholderHasBeenReplaced(): void
     {
-        $expected = '<info>ergebnis/composer-normalize</info> by <info>Andreas Möller</info> and contributors';
+        $version = self::faker()->semver();
+
+        $expected = \sprintf(
+            '<info>ergebnis/composer-normalize</info> %s by <info>Andreas Möller</info> and contributors',
+            $version,
+        );
+
+        self::assertSame($expected, self::longWithVersion($version));
+    }
+
+    public function testLongReturnsVersionWhenPlaceholderHasNotBeenReplaced(): void
+    {
+        $expected = \sprintf(
+            '<info>ergebnis/composer-normalize</info> %s by <info>Andreas Möller</info> and contributors',
+            InstalledVersions::getPrettyVersion('ergebnis/composer-normalize'),
+        );
 
         self::assertSame($expected, Version::long());
+    }
+
+    /**
+     * Simulates a phar, where box has replaced the version placeholder with the version of
+     * the git tag the phar has been built from.
+     */
+    private static function longWithVersion(string $version): string
+    {
+        $property = new \ReflectionProperty(
+            Version::class,
+            'version',
+        );
+
+        $property->setAccessible(true);
+
+        $placeholder = $property->getValue();
+
+        $property->setValue(
+            null,
+            $version,
+        );
+
+        try {
+            return Version::long();
+        } finally {
+            $property->setValue(
+                null,
+                $placeholder,
+            );
+        }
     }
 }


### PR DESCRIPTION
This pull request

- [x] resolves the version from the `composer` runtime when installed as a `composer` plugin

Fixes #1504.
